### PR TITLE
feat(rules): port R003 (MissingRoutingHeaders) to TypeScript (fixes #33)

### DIFF
--- a/src/mcp_migrate/rules/r003_routing_headers.py
+++ b/src/mcp_migrate/rules/r003_routing_headers.py
@@ -26,6 +26,11 @@ MCP_METHOD_RX = re.compile(
 # "missing Mcp-Name" was the bug: it isn't missing, it was never required.
 NAME_REQUIRED_RX = re.compile(r"tools/call|resources/read|prompts/get")
 
+TS_HTTP_CALL = r"\b(?:fetch|axios|got)\s*\(|\.(?:post|request)\s*\("
+TS_MCP_SURFACE_RX = re.compile(
+    r"@modelcontextprotocol|tools/call|tools/list|resources/read|prompts/get|jsonrpc",
+    re.IGNORECASE,
+)
 
 # Submodules that are still "the SDK owns the transport entirely", the same
 # way `mcp.server.fastmcp` is -- importing them is configuration of the
@@ -93,8 +98,14 @@ class MissingRoutingHeaders(Rule):
         "is tools/call, resources/read, or prompts/get -- those are the only methods "
         "that carry a name to route on. Or move to an SDK that sets both for you."
     )
+    languages = ("python", "typescript")
 
     def check(self, project: Project) -> list[Finding]:
+        if project.language == "typescript":
+            return self._check_ts(project)
+        return self._check_python(project)
+
+    def _check_python(self, project: Project) -> list[Finding]:
         # Gate on the project actually importing a raw HTTP client -- without
         # that, ".post(" is almost certainly unrelated (an ORM, a queue, a
         # dataclass method) and flagging it would just be noise.
@@ -146,4 +157,41 @@ class MissingRoutingHeaders(Rule):
                     "by hand but never sets Mcp-Name."
                 )
             out.append(self.finding(message, f, i, line.strip()))
+        return out
+
+    def _check_ts(self, project: Project) -> list[Finding]:
+        out: list[Finding] = []
+        for f in project.files:
+            if not TS_MCP_SURFACE_RX.search(f.text):
+                continue
+
+            missing_method = "mcp-method" not in f.text.lower()
+            requires_name = bool(NAME_REQUIRED_RX.search(f.text))
+            missing_name = requires_name and "mcp-name" not in f.text.lower()
+            if not missing_method and not missing_name:
+                continue
+
+            calls = [
+                (line, text)
+                for file_obj, line, text in project.search_wire(TS_HTTP_CALL)
+                if file_obj.path == f.path
+            ]
+            if not calls:
+                continue
+
+            line, text = calls[0]
+            if missing_method and missing_name:
+                message = (
+                    "This project posts MCP traffic by hand but never sets Mcp-Method, "
+                    "and this call site sends tools/call, resources/read, or prompts/get "
+                    "without Mcp-Name either."
+                )
+            elif missing_method:
+                message = "This project posts MCP traffic by hand but never sets Mcp-Method."
+            else:
+                message = (
+                    "This call site sends tools/call, resources/read, or prompts/get "
+                    "by hand but never sets Mcp-Name."
+                )
+            out.append(self.finding(message, f, line, text))
         return out

--- a/tests/test_typescript.py
+++ b/tests/test_typescript.py
@@ -21,6 +21,7 @@ from mcp_migrate.cli import main, run_check
 from mcp_migrate.rules import all_rules
 from mcp_migrate.rules.base import Project, SourceFile, _ts_spans
 from mcp_migrate.rules.r001_session_id_removed import SessionIdRemoved
+from mcp_migrate.rules.r003_routing_headers import MissingRoutingHeaders
 from mcp_migrate.rules.r006_sse_transport_deprecated import DeprecatedSSETransport
 from mcp_migrate.scan import load_project
 
@@ -84,6 +85,58 @@ def test_neither_fires_on_a_migrated_typescript_server(tmp_path):
     assert DeprecatedSSETransport().check(project) == []
 
 
+def test_r003_finds_missing_headers_in_typescript(tmp_path):
+    code = """\
+import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
+
+export async function callTool(url: string, payload: any) {
+  const res = await fetch(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ method: "tools/call", params: payload })
+  });
+  return res.json();
+}
+"""
+    project = load_project(_write(tmp_path, "client.ts", code))
+    findings = MissingRoutingHeaders().check(project.for_language("typescript"))
+    assert len(findings) == 1
+    assert findings[0].line == 4
+    assert "Mcp-Method" in findings[0].message
+
+
+def test_r003_stays_silent_on_migrated_typescript_client(tmp_path):
+    code = """\
+import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
+
+export async function callTool(url: string, payload: any) {
+  const res = await fetch(url, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "Mcp-Method": "tools/call",
+      "Mcp-Name": "my-tool"
+    },
+    body: JSON.stringify({ method: "tools/call", params: payload })
+  });
+  return res.json();
+}
+"""
+    project = load_project(_write(tmp_path, "client.ts", code)).for_language("typescript")
+    assert MissingRoutingHeaders().check(project) == []
+
+
+def test_r003_ignores_http_calls_named_only_in_comment(tmp_path):
+    code = """\
+import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
+
+// Legacy note: we used fetch(url) to send tools/call without Mcp-Method or Mcp-Name
+export const info = "Migration complete";
+"""
+    project = load_project(_write(tmp_path, "client.ts", code)).for_language("typescript")
+    assert MissingRoutingHeaders().check(project) == []
+
+
 def test_r001_ignores_the_header_named_only_in_prose(tmp_path):
     project = load_project(_write(
         tmp_path, "docs.ts",
@@ -142,7 +195,7 @@ def test_partial_coverage_is_stated_with_a_denominator(tmp_path, capsys):
     # Collapse whitespace: rich wraps at terminal width and will happily
     # split the fraction across two lines.
     out = " ".join(capsys.readouterr().out.split())
-    assert "2 of 21" in out, (
+    assert "3 of 21" in out, (
         "someone deciding whether to trust this needs the coverage fraction, "
         "and it should move as rules get ported"
     )


### PR DESCRIPTION
## What kind of PR is this?

- [ ] Cookbook recipe -- adds/fills in a file in `cookbook/`
- [ ] Rule -- adds/changes a rule in `src/mcp_migrate/rules/`
- [ ] Fixer -- adds/changes a fixer in `src/mcp_migrate/fixers/`
- [ ] Board entry -- adds/updates a `registry/servers/*.yaml` file
- [ ] Something else

## Cookbook recipe

- [ ] Follows `cookbook/_TEMPLATE.md` (Rule/Fixer/Severity/Spec, What broke,
      Before, After, Gotchas, Spec link)
- [ ] Row added to (or moved out of "Stubs" in) `cookbook/README.md`

## Rule

- [ ] `severity` is `breaking`, `deprecated`, or `advisory`
- [ ] `spec_ref` names the spec section or SEP the rule enforces
- [ ] Fixtures added under `tests/fixtures/<rule-id>/`
- [ ] At least one test added and passing (`pytest`)
- [ ] `mcp-migrate rules` lists the new rule

## Fixer

- [ ] `rule_id` matches an existing rule's `id`
- [ ] `confidence` is `safe` only if the transformation cannot change
      behavior beyond what the rule flags -- otherwise `review`
- [ ] Ambiguous shapes are left unchanged (`self.unchanged(source)`), not
      guessed at -- ideally with a fixture proving the backoff
- [ ] A round-trip/idempotency test: running the fixer twice changes
      nothing the second time
- [ ] `mcp-migrate fixers` lists the new fixer

## Board entry

- [ ] Generated with `mcp-migrate entry --repo owner/name`
- [ ] `notes:` edited to a real, one-sentence description
- [ ] `name` matches the filename

## Anything else reviewers should know?

Ported R003 (`MissingRoutingHeaders`) to TypeScript.

- Added `languages = ("python", "typescript")` to `MissingRoutingHeaders` rule class.
- Implemented `_check_ts` using `search_wire` to detect unheadered `fetch( / axios( / got(` calls in code while ignoring comments/docstrings.
- Gated checks on TypeScript files referencing MCP protocol surface (`@modelcontextprotocol`, `tools/call`, `tools/list`, `resources/read`, `prompts/get`, `jsonrpc`).
- Added unit tests in `tests/test_typescript.py` covering legacy client detection, migrated client silence, and comment-only mentions.

Fixes #33
