### PR TITLE
feat(rules): port R005 (NoExtensionsDeclared) to TypeScript

### DIFF
--- a/src/mcp_migrate/rules/r005_extensions.py
+++ b/src/mcp_migrate/rules/r005_extensions.py
@@ -18,6 +18,21 @@ from .base import Finding, Project, Rule
 CAPS_RX = re.compile(r"\bServerCapabilities\b|\bserver_capabilities\b")
 EXTENSIONS_RX = re.compile(r"\bextensions\b")
 
+# --- TypeScript -----------------------------------------------------------
+#
+# ServerCapabilities is the SDK's own type name in TypeScript, same as in
+# Python. The other place capabilities are declared is the options object
+# passed to `new Server({...}, {capabilities: {...}})`, where the type is
+# inferred from the constructor and ServerCapabilities never appears as a
+# name. A bare `capabilities` identifier is far too common to match on its
+# own (91% false-positive rate on the Python side before it was tightened),
+# so the constructor signal is gated on an @modelcontextprotocol/sdk import.
+TS_CAPS_TYPE_RX = r"\bServerCapabilities\b"
+TS_SDK_IMPORT_RX = re.compile(r"@modelcontextprotocol/sdk")
+TS_CAPS_PROP_RX = r"\bcapabilities\s*:\s*\{"
+
+MESSAGE = "Capabilities are declared but `extensions` is absent."
+
 
 class NoExtensionsDeclared(Rule):
     id = "R005"
@@ -28,8 +43,14 @@ class NoExtensionsDeclared(Rule):
         "Optional features now negotiate through `extensions` on ServerCapabilities. "
         "Declare an empty map if you support none -- it tells clients you speak 2026-07-28."
     )
+    languages = ("python", "typescript")
 
     def check(self, project: Project) -> list[Finding]:
+        if project.language == "typescript":
+            return self._check_ts(project)
+        return self._check_python(project)
+
+    def _check_python(self, project: Project) -> list[Finding]:
         out: list[Finding] = []
         seen_files = set()
         # search_code: a comment/docstring that merely mentions
@@ -46,5 +67,40 @@ class NoExtensionsDeclared(Rule):
             if EXTENSIONS_RX.search(f.text):
                 continue
             seen_files.add(f.path)
-            out.append(self.finding("Capabilities are declared but `extensions` is absent.", f, line, text))
+            out.append(self.finding(MESSAGE, f, line, text))
+        return out
+
+    def _check_ts(self, project: Project) -> list[Finding]:
+        out: list[Finding] = []
+        seen_files = set()
+
+        # Signal 1: explicit ServerCapabilities type reference.
+        # search_code skips comments and string literals, so a JSDoc block
+        # or a string mentioning the type is not a declaration.
+        for f, line, text in project.search_code(TS_CAPS_TYPE_RX):
+            if f.path in seen_files:
+                continue
+            if EXTENSIONS_RX.search(f.text):
+                continue
+            seen_files.add(f.path)
+            out.append(self.finding(MESSAGE, f, line, text))
+
+        # Signal 2: capabilities property in a file that imports the MCP
+        # SDK. In TypeScript the type is usually inferred from the Server
+        # constructor, so ServerCapabilities never appears as a name. Gate
+        # on an SDK import to keep the bare `capabilities` false-positive
+        # rate down -- a file that doesn't import @modelcontextprotocol
+        # is not an MCP server, no matter what properties its objects have.
+        # search_wire keeps string literals (for "capabilities": {}) and
+        # drops comments.
+        for f, line, text in project.search_wire(TS_CAPS_PROP_RX):
+            if f.path in seen_files:
+                continue
+            if not TS_SDK_IMPORT_RX.search(f.text):
+                continue
+            if EXTENSIONS_RX.search(f.text):
+                continue
+            seen_files.add(f.path)
+            out.append(self.finding(MESSAGE, f, line, text))
+
         return out

--- a/tests/test_typescript.py
+++ b/tests/test_typescript.py
@@ -23,6 +23,7 @@ from mcp_migrate.rules.base import Project, SourceFile, _ts_spans
 from mcp_migrate.rules.r001_session_id_removed import SessionIdRemoved
 from mcp_migrate.rules.r003_routing_headers import MissingRoutingHeaders
 from mcp_migrate.rules.r006_sse_transport_deprecated import DeprecatedSSETransport
+from mcp_migrate.rules.r005_extensions import NoExtensionsDeclared
 from mcp_migrate.scan import load_project
 
 LEGACY_TS = """\
@@ -147,6 +148,89 @@ def test_r001_ignores_the_header_named_only_in_prose(tmp_path):
     assert SessionIdRemoved().check(project) == []
 
 
+
+# --- R005: extensions map on ServerCapabilities --------------------------
+
+def test_r005_finds_missing_extensions_in_typescript(tmp_path):
+    code = """\
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { ServerCapabilities } from "@modelcontextprotocol/sdk/types.js";
+
+const capabilities: ServerCapabilities = {
+  tools: { listChanged: true },
+  resources: { listChanged: true },
+};
+
+const server = new Server({ name: "my-server", version: "1.0.0" }, { capabilities });
+"""
+    project = load_project(_write(tmp_path, "server.ts", code)).for_language("typescript")
+    findings = NoExtensionsDeclared().check(project)
+    assert len(findings) == 1
+    assert "extensions" in findings[0].message
+
+
+def test_r005_stays_silent_on_migrated_typescript_server(tmp_path):
+    code = """\
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { ServerCapabilities } from "@modelcontextprotocol/sdk/types.js";
+
+const capabilities: ServerCapabilities = {
+  extensions: {},
+  tools: { listChanged: true },
+};
+
+const server = new Server({ name: "my-server", version: "1.0.0" }, { capabilities });
+"""
+    project = load_project(_write(tmp_path, "server.ts", code)).for_language("typescript")
+    assert NoExtensionsDeclared().check(project) == []
+
+
+def test_r005_ignores_servercapabilities_named_only_in_comment(tmp_path):
+    code = """\
+// ServerCapabilities should include an extensions map in 2026-07-28.
+// The capabilities object passed to new Server needs extensions too.
+export const NOTE = 1;
+"""
+    project = load_project(_write(tmp_path, "docs.ts", code)).for_language("typescript")
+    assert NoExtensionsDeclared().check(project) == []
+
+
+def test_r005_finds_missing_extensions_in_constructor_pattern(tmp_path):
+    # The common TS pattern: capabilities passed to new Server without
+    # an explicit ServerCapabilities type reference. The type is inferred
+    # from the constructor, so signal 2 (SDK import + capabilities prop)
+    # is what catches this.
+    code = """\
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+
+const server = new Server(
+  { name: "my-server", version: "1.0.0" },
+  {
+    capabilities: {
+      tools: { listChanged: true },
+    }
+  }
+);
+"""
+    project = load_project(_write(tmp_path, "server.ts", code)).for_language("typescript")
+    findings = NoExtensionsDeclared().check(project)
+    assert len(findings) == 1
+    assert "extensions" in findings[0].message
+
+
+def test_r005_stays_silent_on_non_mcp_typescript(tmp_path):
+    # capabilities: {} is an ordinary property name. Without an SDK import
+    # this is not an MCP server, so the rule stays quiet.
+    code = """\
+const config = {
+  capabilities: {
+    maxRetries: 3,
+  }
+};
+"""
+    project = load_project(_write(tmp_path, "config.ts", code)).for_language("typescript")
+    assert NoExtensionsDeclared().check(project) == []
+
 # --- the language split itself --------------------------------------------
 
 def test_python_rules_never_see_typescript_files(tmp_path):
@@ -195,7 +279,7 @@ def test_partial_coverage_is_stated_with_a_denominator(tmp_path, capsys):
     # Collapse whitespace: rich wraps at terminal width and will happily
     # split the fraction across two lines.
     out = " ".join(capsys.readouterr().out.split())
-    assert "3 of 21" in out, (
+    assert "4 of 21" in out, (
         "someone deciding whether to trust this needs the coverage fraction, "
         "and it should move as rules get ported"
     )


### PR DESCRIPTION
## What kind of PR is this?

- [x] Rule — adds/changes a rule in `src/mcp_migrate/rules/`

## Rule

- [x] `severity` is `breaking`, `deprecated`, or `advisory`
- [x] `spec_ref` names the spec section or SEP the rule enforces
- [x] At least one test added and passing (`pytest`)
- [x] `mcp-migrate rules` lists the new rule

Ports R005 to TypeScript, following the pattern established by R001/R003/R006.

Two detection signals:

1. **Explicit `ServerCapabilities` type reference** — `search_code` skips comments and string literals, so a JSDoc mention or a string is not treated as a declaration.
2. **`capabilities: {}` property in a file that imports `@modelcontextprotocol/sdk`** — the common TS pattern where the type is inferred from the `Server` constructor and `ServerCapabilities` never appears as a name. Gated on an SDK import to keep the bare `capabilities` false-positive rate down (91% on the Python side before it was tightened). Uses `search_wire` so both identifier and string-key forms are caught.

Both signals check the file for `extensions` and stay silent if it appears anywhere, same as the Python rule. The `seen_files` set prevents duplicate findings when both signals match the same file.

Tests added to `tests/test_typescript.py`:
- fires on a TS server with `ServerCapabilities` type, no `extensions`
- silent on a migrated server that declares `extensions: {}`
- silent when `ServerCapabilities` is only named in a comment
- fires on the constructor pattern (`new Server` + `capabilities: {}` + SDK import, no type reference)
- silent on a non-MCP file with a bare `capabilities: {}` property

The partial-coverage denominator test is updated from 3 to 4 of 21, since R005 now reads TypeScript.

Closes #35