### PR TITLE
feat(rules): port R011 (PingRemoved) to TypeScript

### DIFF
--- a/src/mcp_migrate/rules/r011_ping_removed.py
+++ b/src/mcp_migrate/rules/r011_ping_removed.py
@@ -3,8 +3,10 @@ import re
 from .base import Finding, Project, Rule
 
 # `PingRequest` is the MCP SDK's own model name -- distinctive, essentially
-# never appears outside MCP code.
-PING_CODE_RX = re.compile(r"\bPingRequest\b")
+# never appears outside MCP code. In TypeScript the SDK exports
+# `PingRequestSchema` (Zod) and `PingRequest` (inferred type), so we match
+# any identifier starting with PingRequest.
+PING_CODE_RX = re.compile(r"\bPingRequest\w*")
 
 # A bare `"ping"` string is one of the most overloaded tokens in server
 # code (health checks, keepalives, load-balancer probes have nothing to do
@@ -25,6 +27,31 @@ PING_DISPATCH_RX = re.compile(
     r"method\s*==\s*[\"']ping[\"']|case\s*[\"']ping[\"']|[{,]\s*[\"']ping[\"']\s*:"
 )
 
+# --- TypeScript -----------------------------------------------------------
+#
+# Same two signals, adapted for TS syntax. `===` is the idiomatic equality
+# operator in TypeScript, and template literals (backticks) are valid
+# string delimiters. The dispatch-object alternative keeps the same
+# `{`/`,` anchor trick so search_code doesn't drop the match.
+TS_PING_CODE_RX = r"\bPingRequest\w*"
+TS_PING_DISPATCH_RX = (
+    r"method\s*===?\s*[\"'`]ping[\"'`]"
+    r"|case\s+[\"'`]ping[\"'`]\s*:"
+    r"|[{,]\s*[\"'`]ping[\"'`]\s*:"
+)
+
+# `ping` appears in health-check endpoints constantly. Gate signal 2 on
+# the file having some MCP context: an SDK import or a reference to MCP's
+# own JSON-RPC method names. A file that never touches MCP is not
+# dispatching the MCP ping, no matter what string it compares against.
+TS_MCP_SURFACE_RX = re.compile(
+    r"@modelcontextprotocol|tools/call|tools/list|resources/read|prompts/get|jsonrpc",
+    re.IGNORECASE,
+)
+
+MESSAGE_CODE = "References the removed PingRequest handler."
+MESSAGE_DISPATCH = "Dispatches the removed `ping` JSON-RPC method."
+
 
 class PingRemoved(Rule):
     id = "R011"
@@ -35,15 +62,49 @@ class PingRemoved(Rule):
         "ping is gone from the protocol -- liveness now rides on the transport itself. "
         "Remove the handler and rely on your HTTP stack's own keepalive/health checks."
     )
+    languages = ("python", "typescript")
 
     def check(self, project: Project) -> list[Finding]:
+        if project.language == "typescript":
+            return self._check_ts(project)
+        return self._check_python(project)
+
+    def _check_python(self, project: Project) -> list[Finding]:
         out: list[Finding] = []
         for f, line, text in project.search_code(PING_CODE_RX.pattern):
-            out.append(self.finding(
-                "References the removed PingRequest handler.", f, line, text,
-            ))
+            out.append(self.finding(MESSAGE_CODE, f, line, text))
         for f, line, text in project.search_code(PING_DISPATCH_RX.pattern):
-            out.append(self.finding(
-                "Dispatches the removed `ping` JSON-RPC method.", f, line, text,
-            ))
+            out.append(self.finding(MESSAGE_DISPATCH, f, line, text))
         return out
+
+    def _check_ts(self, project: Project) -> list[Finding]:
+        out: list[Finding] = []
+        seen: set[tuple[str, int]] = set()
+
+        # Signal 1: PingRequest identifier. Distinctive enough that no MCP
+        # context gate is needed -- search_code skips comments and string
+        # literals, so a JSDoc mention is not a reference.
+        for f, line, text in project.search_code(TS_PING_CODE_RX):
+            key = (str(f.path), line)
+            if key in seen:
+                continue
+            seen.add(key)
+            out.append(self.finding(MESSAGE_CODE, f, line, text))
+
+        # Signal 2: "ping" as a JSON-RPC method dispatch. Gated on MCP
+        # context because `ping` is one of the most common tokens in
+        # non-MCP server code (health checks, keepalives). The dispatch
+        # patterns start on code tokens (method, case, {, ,) so
+        # search_code finds them despite the "ping" part being a string
+        # literal.
+        mcp_paths = {f.path for f in project.files if TS_MCP_SURFACE_RX.search(f.text)}
+        for f, line, text in project.search_code(TS_PING_DISPATCH_RX):
+            if f.path not in mcp_paths:
+                continue
+            key = (str(f.path), line)
+            if key in seen:
+                continue
+            seen.add(key)
+            out.append(self.finding(MESSAGE_DISPATCH, f, line, text))
+
+        return sorted(out, key=lambda x: (str(x.path or ""), x.line or 0))

--- a/tests/test_typescript.py
+++ b/tests/test_typescript.py
@@ -24,6 +24,7 @@ from mcp_migrate.rules.r001_session_id_removed import SessionIdRemoved
 from mcp_migrate.rules.r003_routing_headers import MissingRoutingHeaders
 from mcp_migrate.rules.r005_extensions import NoExtensionsDeclared
 from mcp_migrate.rules.r006_sse_transport_deprecated import DeprecatedSSETransport
+from mcp_migrate.rules.r011_ping_removed import PingRemoved
 from mcp_migrate.scan import load_project
 
 LEGACY_TS = """\
@@ -231,6 +232,107 @@ const config = {
     assert NoExtensionsDeclared().check(project) == []
 
 
+
+# --- R011: removed ping request/response ---------------------------------
+
+def test_r011_finds_ping_request_schema_in_typescript(tmp_path):
+    code = """\
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { PingRequestSchema } from "@modelcontextprotocol/sdk/types.js";
+
+server.setRequestHandler(PingRequestSchema, async () => {
+  return {};
+});
+"""
+    project = load_project(_write(tmp_path, "server.ts", code)).for_language("typescript")
+    findings = PingRemoved().check(project)
+    assert len(findings) == 2
+    assert all("PingRequest" in f.message for f in findings)
+
+
+def test_r011_finds_method_dispatch_in_typescript(tmp_path):
+    code = """\
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+
+export async function handle(method: string) {
+  if (method === "ping") {
+    return {};
+  }
+}
+"""
+    project = load_project(_write(tmp_path, "server.ts", code)).for_language("typescript")
+    findings = PingRemoved().check(project)
+    assert len(findings) == 1
+    assert "ping" in findings[0].message
+
+
+def test_r011_finds_case_dispatch_in_typescript(tmp_path):
+    code = """\
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+
+switch (method) {
+  case "ping": return {};
+  case "tools/call": return callTool();
+}
+"""
+    project = load_project(_write(tmp_path, "server.ts", code)).for_language("typescript")
+    findings = PingRemoved().check(project)
+    assert len(findings) == 1
+    assert "ping" in findings[0].message
+
+
+def test_r011_stays_silent_on_migrated_typescript_server(tmp_path):
+    code = """\
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+
+const server = new Server({ name: "my-server", version: "1.0.0" });
+"""
+    project = load_project(_write(tmp_path, "server.ts", code)).for_language("typescript")
+    assert PingRemoved().check(project) == []
+
+
+def test_r011_ignores_ping_named_only_in_comment(tmp_path):
+    code = """\
+// We removed the ping handler in the 2026-07-28 migration.
+// PingRequestSchema is gone, liveness rides on the transport now.
+export const NOTE = 1;
+"""
+    project = load_project(_write(tmp_path, "docs.ts", code)).for_language("typescript")
+    assert PingRemoved().check(project) == []
+
+
+def test_r011_stays_silent_on_health_check_endpoint(tmp_path):
+    # A /ping health-check route in a file that also imports the MCP SDK.
+    # The dispatch patterns don't match "/ping" (it has a leading slash),
+    # and there's no method === "ping" comparison, so this stays quiet
+    # even with MCP context present.
+    code = """\
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import express from "express";
+
+const app = express();
+app.get("/ping", (req, res) => res.json({ ok: true }));
+
+const server = new Server({ name: "my-server", version: "1.0.0" });
+"""
+    project = load_project(_write(tmp_path, "server.ts", code)).for_language("typescript")
+    assert PingRemoved().check(project) == []
+
+
+def test_r011_stays_silent_on_ping_dispatch_without_mcp_context(tmp_path):
+    # method === "ping" but no MCP SDK import and no MCP method names.
+    # This is a game server or a network tool, not an MCP server.
+    code = """\
+export function handle(message: string) {
+  if (message === "ping") {
+    return "pong";
+  }
+  return null;
+}
+"""
+    project = load_project(_write(tmp_path, "game.ts", code)).for_language("typescript")
+    assert PingRemoved().check(project) == []
+
 # --- the language split itself --------------------------------------------
 
 def test_python_rules_never_see_typescript_files(tmp_path):
@@ -279,7 +381,7 @@ def test_partial_coverage_is_stated_with_a_denominator(tmp_path, capsys):
     # Collapse whitespace: rich wraps at terminal width and will happily
     # split the fraction across two lines.
     out = " ".join(capsys.readouterr().out.split())
-    assert "4 of 21" in out, (
+    assert "5 of 21" in out, (
         "someone deciding whether to trust this needs the coverage fraction, "
         "and it should move as rules get ported"
     )


### PR DESCRIPTION
## What kind of PR is this?

- [x] Rule — adds/changes a rule in `src/mcp_migrate/rules/`

## Rule

- [x] `severity` is `breaking`, `deprecated`, or `advisory`
- [x] `spec_ref` names the spec section or SEP the rule enforces
- [x] At least one test added and passing (`pytest`)
- [x] `mcp-migrate rules` lists the new rule

Ports R011 to TypeScript, following the pattern from R001/R003/R005/R006.

Two detection signals:

1. **`PingRequest` identifier** — `\bPingRequest\w*` via `search_code`. Broadened from the Python `\bPingRequest\b` because the TS SDK exports `PingRequestSchema` (Zod) alongside the `PingRequest` type. No MCP context gate needed — the identifier is distinctive enough that it essentially never appears outside MCP code.

2. **`"ping"` as a JSON-RPC method dispatch** — `method === "ping"`, `case "ping":`, `{"ping": ...}` via `search_code`. Gated on MCP context (SDK import or MCP method names in the file) because `ping` is one of the most overloaded tokens in server code. The dispatch patterns handle TS syntax: `===` operator, template literals, and `switch case`. The `{`/`,` anchor trick keeps the match start on the code side of the string literal so `search_code` does not drop it.

The gate is the key part: a `/ping` health-check route in a file that also imports the MCP SDK stays silent, and a `message === "ping"` comparison in a file with no MCP context stays silent too.

Tests added to `tests/test_typescript.py`:
- fires on `PingRequestSchema` import + usage (2 findings)
- fires on `method === "ping"` dispatch with MCP context
- fires on `case "ping":` dispatch with MCP context
- silent on a migrated server
- silent when `PingRequest` is only named in a comment
- silent on a `/ping` health-check route in a file with MCP context
- silent on `message === "ping"` in a file without MCP context

The partial-coverage denominator test is updated from 4 to 5 of 21.

Closes #40