### PR TITLE
fix: enable R019 for TypeScript

### DIFF
--- a/src/mcp_migrate/rules/r019_tasks_polling_replaces_blocking_result.py
+++ b/src/mcp_migrate/rules/r019_tasks_polling_replaces_blocking_result.py
@@ -18,8 +18,24 @@ class TasksPollingReplacesBlockingResult(Rule):
         "tasks/get + tasks/update. Tasks itself moved out of core into the "
         "io.modelcontextprotocol/tasks extension -- declare it there instead."
     )
+    languages = ("python", "typescript")
 
     def check(self, project: Project) -> list[Finding]:
+        if project.language == "typescript":
+            # The removed task methods are JSON-RPC wire names, so they
+            # appear as string literals. search_wire keeps those literals
+            # while ignoring comments that merely describe the migration.
+            return [
+                self.finding(
+                    "References the removed tasks/list or blocking tasks/result JSON-RPC "
+                    "method.",
+                    f,
+                    line,
+                    text,
+                )
+                for f, line, text in project.search_wire(r"tasks/list|tasks/result")
+            ]
+
         out: list[Finding] = []
         for f, line, text in project.search_code(TASKS_CODE_RX.pattern):
             out.append(self.finding(

--- a/tests/test_typescript.py
+++ b/tests/test_typescript.py
@@ -25,6 +25,9 @@ from mcp_migrate.rules.r003_routing_headers import MissingRoutingHeaders
 from mcp_migrate.rules.r004_tool_ordering import NondeterministicToolOrder
 from mcp_migrate.rules.r005_extensions import NoExtensionsDeclared
 from mcp_migrate.rules.r006_sse_transport_deprecated import DeprecatedSSETransport
+from mcp_migrate.rules.r019_tasks_polling_replaces_blocking_result import (
+    TasksPollingReplacesBlockingResult,
+)
 from mcp_migrate.rules.r011_ping_removed import PingRemoved
 from mcp_migrate.rules.r015_result_type_required import RequiredResultTypeMissing
 from mcp_migrate.rules.r016_cacheable_result_required import (
@@ -85,6 +88,45 @@ def test_r006_finds_sse_in_typescript(tmp_path):
     findings = DeprecatedSSETransport().check(project.for_language("typescript"))
     # The SDK import, the route literal, and the constructor.
     assert len(findings) >= 2
+
+
+def test_r019_finds_removed_task_methods_in_typescript(tmp_path):
+    code = """\
+export function listTasks() {
+  return { method: "tasks/list" };
+}
+
+export function waitForTask() {
+  return { method: "tasks/result" };
+}
+"""
+    project = load_project(_write(tmp_path, "tasks.ts", code)).for_language("typescript")
+    findings = TasksPollingReplacesBlockingResult().check(project)
+    assert len(findings) == 2
+    assert [finding.line for finding in findings] == [2, 6]
+
+
+def test_r019_stays_silent_on_migrated_typescript_server(tmp_path):
+    code = """\
+export function pollTask() {
+  return { method: "tasks/get" };
+}
+
+export function updateTask() {
+  return { method: "tasks/update" };
+}
+"""
+    project = load_project(_write(tmp_path, "tasks.ts", code)).for_language("typescript")
+    assert TasksPollingReplacesBlockingResult().check(project) == []
+
+
+def test_r019_ignores_typescript_comment_only_mentions(tmp_path):
+    code = """\
+// tasks/list and tasks/result were replaced by polling tasks/get.
+export const protocolVersion = "2026-07-28";
+"""
+    project = load_project(_write(tmp_path, "notes.ts", code)).for_language("typescript")
+    assert TasksPollingReplacesBlockingResult().check(project) == []
 
 
 def test_r015_finds_missing_result_type_in_typescript(tmp_path):


### PR DESCRIPTION
## Summary

- enable rule R019 for TypeScript projects
- detect only the removed `tasks/list` and blocking `tasks/result` wire literals
- add positive, migrated, and comment-only regression coverage

Fixes #48

## Validation

- `uv run --extra dev pytest tests/test_typescript.py -v` (25 passed)
- `uv run --extra dev pytest -v` (193 passed)
- `uv run mcp-migrate rules`
- `git diff --check`

## AI assistance

Prepared with GPT-5.6 assistance and reviewed against the existing Python implementation and TypeScript comment-aware scanner.