### PR TITLE
fix: enable R021 for TypeScript

### DIFF
--- a/src/mcp_migrate/rules/r021_json_schema_2020_12_required.py
+++ b/src/mcp_migrate/rules/r021_json_schema_2020_12_required.py
@@ -26,8 +26,19 @@ class OldJSONSchemaDialect(Rule):
         "outputSchema. If you pin an older draft explicitly, move it to 2020-12 (or "
         "drop the pin and let a modern validator pick the default)."
     )
+    languages = ("python", "typescript")
+
+    MESSAGE = "Pins an older JSON Schema dialect; 2026-07-28 requires 2020-12 support."
 
     def check(self, project: Project) -> list[Finding]:
+        if project.language == "typescript":
+            # A TypeScript schema pin is a string literal. search_wire keeps
+            # the literal but ignores comments that only describe the upgrade.
+            return [
+                self.finding(self.MESSAGE, f, line, text)
+                for f, line, text in project.search_wire(OLD_DIALECT_RX.pattern)
+            ]
+
         out: list[Finding] = []
         # Raw text, not search_code: a `$schema` dialect pin is always a
         # URL/date string (`"http://json-schema.org/draft-07/schema#"`,
@@ -35,8 +46,5 @@ class OldJSONSchemaDialect(Rule):
         # starts inside a STRING token -- search_code would silently never
         # find it (see the notifications/initialized note in r009).
         for f, line, text in project.search_wire(OLD_DIALECT_RX.pattern):
-            out.append(self.finding(
-                "Pins an older JSON Schema dialect; 2026-07-28 requires 2020-12 support.",
-                f, line, text,
-            ))
+            out.append(self.finding(self.MESSAGE, f, line, text))
         return out

--- a/tests/test_typescript.py
+++ b/tests/test_typescript.py
@@ -25,6 +25,7 @@ from mcp_migrate.rules.r003_routing_headers import MissingRoutingHeaders
 from mcp_migrate.rules.r004_tool_ordering import NondeterministicToolOrder
 from mcp_migrate.rules.r005_extensions import NoExtensionsDeclared
 from mcp_migrate.rules.r006_sse_transport_deprecated import DeprecatedSSETransport
+from mcp_migrate.rules.r021_json_schema_2020_12_required import OldJSONSchemaDialect
 from mcp_migrate.rules.r011_ping_removed import PingRemoved
 from mcp_migrate.rules.r015_result_type_required import RequiredResultTypeMissing
 from mcp_migrate.rules.r016_cacheable_result_required import (
@@ -85,6 +86,39 @@ def test_r006_finds_sse_in_typescript(tmp_path):
     findings = DeprecatedSSETransport().check(project.for_language("typescript"))
     # The SDK import, the route literal, and the constructor.
     assert len(findings) >= 2
+
+
+def test_r021_finds_old_schema_dialect_in_typescript(tmp_path):
+    code = """\
+export const inputSchema = {
+  "$schema": "https://json-schema.org/draft-07/schema#",
+  type: "object",
+};
+"""
+    project = load_project(_write(tmp_path, "schema.ts", code)).for_language("typescript")
+    findings = OldJSONSchemaDialect().check(project)
+    assert len(findings) == 1
+    assert findings[0].line == 2
+
+
+def test_r021_stays_silent_on_migrated_typescript_server(tmp_path):
+    code = """\
+export const inputSchema = {
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  type: "object",
+};
+"""
+    project = load_project(_write(tmp_path, "schema.ts", code)).for_language("typescript")
+    assert OldJSONSchemaDialect().check(project) == []
+
+
+def test_r021_ignores_typescript_comment_only_mentions(tmp_path):
+    code = """\
+// Replace draft-07 with JSON Schema 2020-12 before publishing this schema.
+export const protocolVersion = "2026-07-28";
+"""
+    project = load_project(_write(tmp_path, "notes.ts", code)).for_language("typescript")
+    assert OldJSONSchemaDialect().check(project) == []
 
 
 def test_r015_finds_missing_result_type_in_typescript(tmp_path):


### PR DESCRIPTION
## Summary

- enable rule R021 for TypeScript projects
- detect explicit legacy JSON Schema dialect pins while ignoring comments
- add positive, migrated, and comment-only regression coverage

Fixes #50

## Validation

- `uv run --extra dev pytest tests/test_typescript.py -v` (25 passed)
- `uv run --extra dev pytest -v` (193 passed)
- `uv run mcp-migrate rules`
- `git diff --check`

## AI assistance

Prepared with GPT-5.6 assistance and reviewed against the existing Python implementation and TypeScript comment-aware scanner.