### PR TITLE
fix: enable R018 for TypeScript

### DIFF
--- a/src/mcp_migrate/rules/r018_multi_round_trip_replaces_server_initiated.py
+++ b/src/mcp_migrate/rules/r018_multi_round_trip_replaces_server_initiated.py
@@ -31,6 +31,15 @@ FEATURES_LITERAL = {
     r"notifications/elicitation/complete": "notifications/elicitation/complete",
 }
 
+# The TypeScript SDK exports Zod schemas for request handling. These names
+# are specific to the removed MCP server-initiated requests, unlike generic
+# callback names such as `createMessage` or `listRoots`.
+TS_FEATURES_CODE = {
+    r"\bListRootsRequestSchema\b": "Server-initiated roots/list",
+    r"\bCreateMessageRequestSchema\b": "Server-initiated sampling/createMessage",
+    r"\bElicitRequestSchema\b": "Server-initiated elicitation/create",
+}
+
 
 class MultiRoundTripReplacesServerInitiated(Rule):
     id = "R018"
@@ -43,8 +52,31 @@ class MultiRoundTripReplacesServerInitiated(Rule):
         "an InputRequiredResult instead and let the client retry the call with "
         "inputResponses."
     )
+    languages = ("python", "typescript")
 
     def check(self, project: Project) -> list[Finding]:
+        if project.language == "typescript":
+            out: list[Finding] = []
+            for pattern, name in TS_FEATURES_CODE.items():
+                for f, line, text in project.search_code(pattern):
+                    out.append(self.finding(
+                        f"{name} was replaced by Multi Round-Trip Requests (InputRequiredResult "
+                        "+ inputResponses).",
+                        f,
+                        line,
+                        text,
+                    ))
+            for pattern, name in FEATURES_LITERAL.items():
+                for f, line, text in project.search_wire(pattern):
+                    out.append(self.finding(
+                        f"{name} was replaced by Multi Round-Trip Requests (InputRequiredResult "
+                        "+ inputResponses).",
+                        f,
+                        line,
+                        text,
+                    ))
+            return out
+
         out: list[Finding] = []
         for pattern, name in FEATURES_CODE.items():
             # search_code: a comment/docstring mentioning "sampling" or

--- a/tests/test_typescript.py
+++ b/tests/test_typescript.py
@@ -30,6 +30,9 @@ from mcp_migrate.rules.r015_result_type_required import RequiredResultTypeMissin
 from mcp_migrate.rules.r016_cacheable_result_required import (
     CacheableResultMetadataMissing,
 )
+from mcp_migrate.rules.r018_multi_round_trip_replaces_server_initiated import (
+    MultiRoundTripReplacesServerInitiated,
+)
 from mcp_migrate.rules.r020_dynamic_client_registration_deprecated import (
     DynamicClientRegistrationDeprecated,
 )
@@ -85,6 +88,40 @@ def test_r006_finds_sse_in_typescript(tmp_path):
     findings = DeprecatedSSETransport().check(project.for_language("typescript"))
     # The SDK import, the route literal, and the constructor.
     assert len(findings) >= 2
+
+
+def test_r018_finds_server_initiated_request_in_typescript(tmp_path):
+    code = """\
+import { CreateMessageRequestSchema } from "@modelcontextprotocol/sdk/types.js";
+
+server.setRequestHandler(CreateMessageRequestSchema, async () => ({}));
+export const legacyMethod = "sampling/createMessage";
+"""
+    project = load_project(_write(tmp_path, "requests.ts", code)).for_language(
+        "typescript"
+    )
+    findings = MultiRoundTripReplacesServerInitiated().check(project)
+    assert len(findings) == 3
+    assert [finding.line for finding in findings] == [1, 3, 4]
+
+
+def test_r018_stays_silent_on_migrated_typescript_server(tmp_path):
+    code = """\
+export const inputRequiredResult = { inputResponses: [] };
+"""
+    project = load_project(_write(tmp_path, "requests.ts", code)).for_language(
+        "typescript"
+    )
+    assert MultiRoundTripReplacesServerInitiated().check(project) == []
+
+
+def test_r018_ignores_typescript_comment_only_mentions(tmp_path):
+    code = """\
+// CreateMessageRequestSchema and sampling/createMessage were replaced by MRTR.
+export const protocolVersion = "2026-07-28";
+"""
+    project = load_project(_write(tmp_path, "notes.ts", code)).for_language("typescript")
+    assert MultiRoundTripReplacesServerInitiated().check(project) == []
 
 
 def test_r015_finds_missing_result_type_in_typescript(tmp_path):


### PR DESCRIPTION
## Summary
- enable R018 (Multi Round-Trip Requests) for TypeScript
- match specific legacy TypeScript SDK request schemas and legacy wire-method literals
- add positive, migrated, and comment-only coverage

Fixes #47

## Validation
- uv run --extra dev pytest tests/test_typescript.py -v (25 passed)
- uv run --extra dev pytest -v (193 passed)
- uv run mcp-migrate rules
- git diff --check

Assisted by GPT-5.6; implementation and validation were reviewed by the author.