### PR TITLE
fix: enable R014 for TypeScript

### DIFF
--- a/src/mcp_migrate/rules/r014_sse_resumability_removed.py
+++ b/src/mcp_migrate/rules/r014_sse_resumability_removed.py
@@ -1,4 +1,20 @@
+import re
+
 from .base import Finding, Project, Rule
+
+# --- TypeScript -----------------------------------------------------------
+
+# TypeScript servers commonly keep the header value in a camel-cased local
+# before passing it to their replay store. The identifiers are specific enough
+# to be code-only matches, while the wire name itself must be kept in a string
+# literal and is therefore matched only in a header access.
+TS_IDENT_RX = r"\blastEventId\b|\blast_event_id\b|\bLAST_EVENT_ID\b"
+TS_HEADER_RX = (
+    r"headers?\s*(?:\[|\.get\s*\(|\.set\s*\(|\.delete\s*\()\s*"
+    r"[\"'`]last-event-id[\"'`]"
+    r"|[\"'`]last-event-id[\"'`]\s*\]"
+    r"|setHeader\s*\(\s*[\"'`]last-event-id[\"'`]"
+)
 
 
 class SSEResumabilityRemoved(Rule):
@@ -11,8 +27,14 @@ class SSEResumabilityRemoved(Rule):
         "event store / replay logic -- a dropped connection is just a dropped connection "
         "now, the client issues a fresh request."
     )
+    languages = ("python", "typescript")
 
     def check(self, project: Project) -> list[Finding]:
+        if project.language == "typescript":
+            return self._check_ts(project)
+        return self._check_python(project)
+
+    def _check_python(self, project: Project) -> list[Finding]:
         out: list[Finding] = []
         # search_code: a comment noting "we don't support Last-Event-ID"
         # (like the comment_only_mentions fixture pattern for R001) isn't a
@@ -27,3 +49,24 @@ class SSEResumabilityRemoved(Rule):
                 f, line, text,
             ))
         return out
+
+    def _check_ts(self, project: Project) -> list[Finding]:
+        # search_code catches executable identifier use while ignoring prose;
+        # search_wire retains the quoted HTTP header while still ignoring
+        # comments. Deduplicate the common `const lastEventId =
+        # req.headers.get("Last-Event-ID")` form into one finding.
+        seen: set[tuple[str, int]] = set()
+        out: list[Finding] = []
+        for pattern, search in (
+            (TS_IDENT_RX, project.search_code),
+            (TS_HEADER_RX, project.search_wire),
+        ):
+            for f, line, text in search(pattern, flags=re.IGNORECASE):
+                if (str(f.path), line) in seen:
+                    continue
+                seen.add((str(f.path), line))
+                out.append(self.finding(
+                    "Implements SSE resumability (Last-Event-ID) -- removed from the transport.",
+                    f, line, text,
+                ))
+        return sorted(out, key=lambda x: (str(x.path or ""), x.line or 0))

--- a/tests/test_typescript.py
+++ b/tests/test_typescript.py
@@ -26,6 +26,7 @@ from mcp_migrate.rules.r004_tool_ordering import NondeterministicToolOrder
 from mcp_migrate.rules.r005_extensions import NoExtensionsDeclared
 from mcp_migrate.rules.r006_sse_transport_deprecated import DeprecatedSSETransport
 from mcp_migrate.rules.r011_ping_removed import PingRemoved
+from mcp_migrate.rules.r014_sse_resumability_removed import SSEResumabilityRemoved
 from mcp_migrate.rules.r015_result_type_required import RequiredResultTypeMissing
 from mcp_migrate.rules.r016_cacheable_result_required import (
     CacheableResultMetadataMissing,
@@ -85,6 +86,37 @@ def test_r006_finds_sse_in_typescript(tmp_path):
     findings = DeprecatedSSETransport().check(project.for_language("typescript"))
     # The SDK import, the route literal, and the constructor.
     assert len(findings) >= 2
+
+
+def test_r014_finds_last_event_id_resumability_in_typescript(tmp_path):
+    code = """\
+export async function resume(req, eventStore) {
+  const lastEventId = req.headers.get("Last-Event-ID");
+  return eventStore.replayAfter(lastEventId);
+}
+"""
+    project = load_project(_write(tmp_path, "transport.ts", code)).for_language("typescript")
+    findings = SSEResumabilityRemoved().check(project)
+    assert [finding.line for finding in findings] == [2, 3]
+
+
+def test_r014_stays_silent_on_migrated_typescript_server(tmp_path):
+    code = """\
+export async function handle(req) {
+  return req.json();
+}
+"""
+    project = load_project(_write(tmp_path, "transport.ts", code)).for_language("typescript")
+    assert SSEResumabilityRemoved().check(project) == []
+
+
+def test_r014_ignores_last_event_id_named_only_in_comment(tmp_path):
+    code = """\
+// Last-Event-ID and lastEventId replay support were removed in this migration.
+export const VERSION = "2026-07-28";
+"""
+    project = load_project(_write(tmp_path, "transport.ts", code)).for_language("typescript")
+    assert SSEResumabilityRemoved().check(project) == []
 
 
 def test_r015_finds_missing_result_type_in_typescript(tmp_path):


### PR DESCRIPTION
## Summary
- enable R014 (SSE resumability removal) for TypeScript
- distinguish executable identifiers and Last-Event-ID wire-header accesses while ignoring comments
- add positive, migrated, and comment-only coverage

Fixes #43

## Validation
- uv run --extra dev pytest tests/test_typescript.py -v (25 passed)
- uv run --extra dev pytest -v (193 passed)
- uv run mcp-migrate rules
- git diff --check

Assisted by GPT-5.6; implementation and validation were reviewed by the author.