### PR TITLE
feat(rules): port R004 (NondeterministicToolOrder) to TypeScript (fixes #34)

### DIFF
--- a/src/mcp_migrate/rules/r004_tool_ordering.py
+++ b/src/mcp_migrate/rules/r004_tool_ordering.py
@@ -46,6 +46,10 @@ def _body_bounds(lines: list[str], line_no: int) -> tuple[int, int]:
     return body_start, end
 
 
+TS_HANDLER_RX = re.compile(r"ListToolsRequestSchema|listTools|tools/list", re.IGNORECASE)
+TS_SORT_RX = re.compile(r"\.(?:sort|toSorted)\s*\(|\bsorted\s*\(|\bsortBy\b|\borderBy\b", re.IGNORECASE)
+
+
 class NondeterministicToolOrder(Rule):
     id = "R004"
     title = "tools/list order is not deterministic"
@@ -55,8 +59,14 @@ class NondeterministicToolOrder(Rule):
         "Sort the tools you return. Stable ordering lets clients cache and it lifts "
         "LLM prompt-cache hit rates for everyone downstream."
     )
+    languages = ("python", "typescript")
 
     def check(self, project: Project) -> list[Finding]:
+        if project.language == "typescript":
+            return self._check_ts(project)
+        return self._check_python(project)
+
+    def _check_python(self, project: Project) -> list[Finding]:
         out: list[Finding] = []
         for f in project.files:
             # A decorator (`@server.list_tools()`) and the `def` line right
@@ -89,6 +99,33 @@ class NondeterministicToolOrder(Rule):
 
                 window = "\n".join(f.lines[line_no - 1:end_line])
                 if "sorted(" in window or ".sort(" in window:
+                    continue
+                out.append(self.finding(
+                    "Tools are returned without an explicit sort.", f, line_no, line.strip(),
+                ))
+        return out
+
+    def _check_ts(self, project: Project) -> list[Finding]:
+        out: list[Finding] = []
+        for f in project.files:
+            covered: list[tuple[int, int]] = []
+            prose = project._prose_spans_for(f)
+            for line_no, line in enumerate(f.lines, start=1):
+                if line.strip().startswith("import "):
+                    continue
+                m = TS_HANDLER_RX.search(line)
+                if not m:
+                    continue
+                if prose is not None and _in_content_span(line_no, m.start(), prose):
+                    continue
+                if any(start <= line_no <= end for start, end in covered):
+                    continue
+
+                end_line = min(len(f.lines), line_no + 40)
+                covered.append((line_no, end_line))
+
+                window = "\n".join(f.lines[line_no - 1:end_line])
+                if TS_SORT_RX.search(window):
                     continue
                 out.append(self.finding(
                     "Tools are returned without an explicit sort.", f, line_no, line.strip(),

--- a/tests/test_typescript.py
+++ b/tests/test_typescript.py
@@ -22,6 +22,7 @@ from mcp_migrate.rules import all_rules
 from mcp_migrate.rules.base import Project, SourceFile, _ts_spans
 from mcp_migrate.rules.r001_session_id_removed import SessionIdRemoved
 from mcp_migrate.rules.r003_routing_headers import MissingRoutingHeaders
+from mcp_migrate.rules.r004_tool_ordering import NondeterministicToolOrder
 from mcp_migrate.rules.r005_extensions import NoExtensionsDeclared
 from mcp_migrate.rules.r006_sse_transport_deprecated import DeprecatedSSETransport
 from mcp_migrate.scan import load_project
@@ -274,12 +275,52 @@ def test_typescript_only_tree_reports_findings_without_a_grade(tmp_path, capsys)
     assert "partial" in data["reason"]
 
 
+def test_r004_finds_unsorted_tools_in_typescript(tmp_path):
+    code = """\
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js";
+
+const server = new Server({ name: "example", version: "1.0.0" });
+server.setRequestHandler(ListToolsRequestSchema, async () => {
+  return {
+    tools: [
+      { name: "b_tool", description: "B" },
+      { name: "a_tool", description: "A" }
+    ]
+  };
+});
+"""
+    project = load_project(_write(tmp_path, "server.ts", code)).for_language("typescript")
+    findings = NondeterministicToolOrder().check(project)
+    assert len(findings) == 1
+    assert findings[0].line == 5
+    assert "Tools are returned without an explicit sort." in findings[0].message
+
+
+def test_r004_stays_silent_on_sorted_tools_in_typescript(tmp_path):
+    code = """\
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js";
+
+const server = new Server({ name: "example", version: "1.0.0" });
+server.setRequestHandler(ListToolsRequestSchema, async () => {
+  const tools = [
+    { name: "b_tool", description: "B" },
+    { name: "a_tool", description: "A" }
+  ];
+  return { tools: tools.sort((a, b) => a.name.localeCompare(b.name)) };
+});
+"""
+    project = load_project(_write(tmp_path, "server.ts", code)).for_language("typescript")
+    assert NondeterministicToolOrder().check(project) == []
+
+
 def test_partial_coverage_is_stated_with_a_denominator(tmp_path, capsys):
     main(["check", str(_write(tmp_path, "transport.ts", LEGACY_TS))])
     # Collapse whitespace: rich wraps at terminal width and will happily
     # split the fraction across two lines.
     out = " ".join(capsys.readouterr().out.split())
-    assert "4 of 21" in out, (
+    assert "5 of 21" in out, (
         "someone deciding whether to trust this needs the coverage fraction, "
         "and it should move as rules get ported"
     )


### PR DESCRIPTION
…es #34)

## What kind of PR is this?

- [ ] Cookbook recipe -- adds/fills in a file in `cookbook/`
- [ ] Rule -- adds/changes a rule in `src/mcp_migrate/rules/`
- [ ] Fixer -- adds/changes a fixer in `src/mcp_migrate/fixers/`
- [ ] Board entry -- adds/updates a `registry/servers/*.yaml` file
- [ ] Something else

## Cookbook recipe

- [ ] Follows `cookbook/_TEMPLATE.md` (Rule/Fixer/Severity/Spec, What broke,
      Before, After, Gotchas, Spec link)
- [ ] Row added to (or moved out of "Stubs" in) `cookbook/README.md`

## Rule

- [ ] `severity` is `breaking`, `deprecated`, or `advisory`
- [ ] `spec_ref` names the spec section or SEP the rule enforces
- [ ] Fixtures added under `tests/fixtures/<rule-id>/`
- [ ] At least one test added and passing (`pytest`)
- [ ] `mcp-migrate rules` lists the new rule

## Fixer

- [ ] `rule_id` matches an existing rule's `id`
- [ ] `confidence` is `safe` only if the transformation cannot change
      behavior beyond what the rule flags -- otherwise `review`
- [ ] Ambiguous shapes are left unchanged (`self.unchanged(source)`), not
      guessed at -- ideally with a fixture proving the backoff
- [ ] A round-trip/idempotency test: running the fixer twice changes
      nothing the second time
- [ ] `mcp-migrate fixers` lists the new fixer

## Board entry

- [ ] Generated with `mcp-migrate entry --repo owner/name`
- [ ] `notes:` edited to a real, one-sentence description
- [ ] `name` matches the filename

## Anything else reviewers should know?

Ported R004 (`NondeterministicToolOrder`) to TypeScript.

- Added `languages = ("python", "typescript")` to `NondeterministicToolOrder` rule class.
- Implemented `_check_ts` to scan TypeScript handler definitions (`ListToolsRequestSchema`, `listTools`, `tools/list`) and verify explicit tool sorting (`.sort()`, `.toSorted()`, `sortBy`, `orderBy`).
- Added unit tests in `tests/test_typescript.py` covering unsorted handler detection and sorted handler silence.
- Updated coverage fraction assertion to `5 of 21`.

Fixes #34