### PR TITLE
feat(rules): port R015 (resultType) to TypeScript

### DIFF
--- a/src/mcp_migrate/rules/r015_result_type_required.py
+++ b/src/mcp_migrate/rules/r015_result_type_required.py
@@ -36,12 +36,19 @@ RESULT_TYPE_MENTION_RX = re.compile(r"resultType")
 # JSON-RPC responses and therefore owns the envelope itself.
 SDK_SERVER_MODULES = ("mcp.server", "mcp.types", "mcp.shared", "fastmcp")
 
+# TypeScript. The official SDK stamps resultType on every result it
+# serializes, same as the Python runner -- a file that imports
+# @modelcontextprotocol/sdk has nothing to add and nothing to fix.
+TS_SDK_IMPORT_RX = re.compile(r"@modelcontextprotocol/sdk")
+
 # What a server that owns its own envelope looks like: it writes the JSON-RPC
 # framing and the MCP method names itself, as string literals. Both halves are
 # required -- "jsonrpc" alone is any JSON-RPC service on earth, and a method
 # name alone shows up in tests and docs -- and the project must not import the
 # SDK, which is checked first.
 JSONRPC_ENVELOPE_RX = re.compile(r"[\"']jsonrpc[\"']")
+# TypeScript object literals usually use an unquoted `jsonrpc:` key.
+TS_JSONRPC_ENVELOPE_RX = re.compile(r"\bjsonrpc\s*:")
 MCP_METHOD_NAME_RX = re.compile(
     r"[\"'](?:tools/list|tools/call|resources/list|resources/read|"
     r"resources/templates/list|prompts/list|prompts/get)[\"']"
@@ -53,6 +60,10 @@ def _sdk_owns_serialization(project) -> bool:
         if mod == "mcp" or mod.startswith(SDK_SERVER_MODULES):
             return True
     return False
+
+
+def _ts_sdk_owns_serialization(project: Project) -> bool:
+    return any(TS_SDK_IMPORT_RX.search(f.text) for f in project.files)
 
 
 # Downgraded from "breaking" after auditing real servers: resultType is a
@@ -79,8 +90,20 @@ class RequiredResultTypeMissing(Rule):
         "return. On the official SDK you do not need to do anything: the runner "
         "stamps resultType on every result it serializes."
     )
+    languages = ("python", "typescript")
+
+    MESSAGE = (
+        "This file builds JSON-RPC responses for MCP methods without the "
+        "official SDK, so it owns the result envelope, and `resultType` "
+        "never appears in it."
+    )
 
     def check(self, project: Project) -> list[Finding]:
+        if project.language == "typescript":
+            return self._check_ts(project)
+        return self._check_python(project)
+
+    def _check_python(self, project: Project) -> list[Finding]:
         # The SDK stamps `resultType` on every result it serializes, so an
         # SDK-based server has nothing to add and this rule has nothing to
         # say. Only a project that owns its own JSON-RPC envelope can be
@@ -106,9 +129,41 @@ class RequiredResultTypeMissing(Rule):
             line = f.text[: m.start()].count("\n") + 1
             seen_files.add(f.path)
             out.append(self.finding(
-                "This file builds JSON-RPC responses for MCP methods without the "
-                "official SDK, so it owns the result envelope, and `resultType` "
-                "never appears in it.",
+                self.MESSAGE,
                 f, line, f.lines[line - 1].strip() if line <= len(f.lines) else None,
             ))
+        return out
+
+    def _check_ts(self, project: Project) -> list[Finding]:
+        if _ts_sdk_owns_serialization(project):
+            return []
+        out: list[Finding] = []
+        seen_files = set()
+        for f in project.files:
+            if RESULT_TYPE_MENTION_RX.search(f.text):
+                continue
+            if f.path in seen_files:
+                continue
+            # search_wire keeps string literals ("jsonrpc", "tools/list")
+            # and drops comments -- a README-style comment naming the
+            # protocol is not a hand-rolled envelope.
+            has_jsonrpc = any(
+                ff.path == f.path
+                for ff, _line, _text in project.search_wire(TS_JSONRPC_ENVELOPE_RX.pattern)
+            ) or any(
+                ff.path == f.path
+                for ff, _line, _text in project.search_wire(JSONRPC_ENVELOPE_RX.pattern)
+            )
+            if not has_jsonrpc:
+                continue
+            method_hit: tuple[int, str] | None = None
+            for ff, line, text in project.search_wire(MCP_METHOD_NAME_RX.pattern):
+                if ff.path == f.path:
+                    method_hit = (line, text)
+                    break
+            if method_hit is None:
+                continue
+            line, text = method_hit
+            seen_files.add(f.path)
+            out.append(self.finding(self.MESSAGE, f, line, text))
         return out

--- a/tests/test_typescript.py
+++ b/tests/test_typescript.py
@@ -24,6 +24,7 @@ from mcp_migrate.rules.r001_session_id_removed import SessionIdRemoved
 from mcp_migrate.rules.r003_routing_headers import MissingRoutingHeaders
 from mcp_migrate.rules.r005_extensions import NoExtensionsDeclared
 from mcp_migrate.rules.r006_sse_transport_deprecated import DeprecatedSSETransport
+from mcp_migrate.rules.r015_result_type_required import RequiredResultTypeMissing
 from mcp_migrate.scan import load_project
 
 LEGACY_TS = """\
@@ -76,6 +77,91 @@ def test_r006_finds_sse_in_typescript(tmp_path):
     findings = DeprecatedSSETransport().check(project.for_language("typescript"))
     # The SDK import, the route literal, and the constructor.
     assert len(findings) >= 2
+
+
+def test_r015_finds_missing_result_type_in_typescript(tmp_path):
+    code = """\
+export function handle(request: { method: string; id: string | number }) {
+  if (request.method === "tools/list") {
+    return JSON.stringify({
+      jsonrpc: "2.0",
+      id: request.id,
+      result: { tools: [{ name: "echo", description: "Echo input" }] },
+    });
+  }
+  return JSON.stringify({
+    jsonrpc: "2.0",
+    id: request.id,
+    error: { code: -32601, message: "Method not found" },
+  });
+}
+"""
+    project = load_project(_write(tmp_path, "server.ts", code)).for_language("typescript")
+    findings = RequiredResultTypeMissing().check(project)
+    assert len(findings) == 1
+    assert findings[0].line == 2
+
+
+def test_r015_stays_silent_on_migrated_typescript_server(tmp_path):
+    code = """\
+export function handle(request: { method: string; id: string | number }) {
+  if (request.method === "tools/list") {
+    return JSON.stringify({
+      jsonrpc: "2.0",
+      id: request.id,
+      result: { tools: [], resultType: "complete" },
+    });
+  }
+}
+"""
+    project = load_project(_write(tmp_path, "server.ts", code)).for_language("typescript")
+    assert RequiredResultTypeMissing().check(project) == []
+
+
+def test_r015_finds_missing_result_type_with_quoted_jsonrpc_key(tmp_path):
+    code = """\
+export function handle(request: { method: string; id: string | number }) {
+  if (request.method === "tools/list") {
+    return JSON.stringify({
+      "jsonrpc": "2.0",
+      id: request.id,
+      result: { tools: [] },
+    });
+  }
+}
+"""
+    project = load_project(_write(tmp_path, "server.ts", code)).for_language("typescript")
+    findings = RequiredResultTypeMissing().check(project)
+    assert len(findings) == 1
+
+
+def test_r015_ignores_jsonrpc_named_only_in_comment(tmp_path):
+    code = """\
+// This file builds jsonrpc responses for tools/list without resultType.
+export const NOTE = 1;
+"""
+    project = load_project(_write(tmp_path, "docs.ts", code)).for_language("typescript")
+    assert RequiredResultTypeMissing().check(project) == []
+
+
+def test_r015_stays_silent_when_sdk_owns_serialization(tmp_path):
+    code = """\
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+
+export function handle(request: { method: string; id: string | number }) {
+  if (request.method === "tools/list") {
+    return JSON.stringify({
+      jsonrpc: "2.0",
+      id: request.id,
+      result: { tools: [] },
+    });
+  }
+}
+
+const server = new Server({ name: "my-server", version: "1.0.0" }, { capabilities: {} });
+"""
+    project = load_project(_write(tmp_path, "server.ts", code)).for_language("typescript")
+    assert RequiredResultTypeMissing().check(project) == []
 
 
 def test_neither_fires_on_a_migrated_typescript_server(tmp_path):
@@ -279,7 +365,7 @@ def test_partial_coverage_is_stated_with_a_denominator(tmp_path, capsys):
     # Collapse whitespace: rich wraps at terminal width and will happily
     # split the fraction across two lines.
     out = " ".join(capsys.readouterr().out.split())
-    assert "4 of 21" in out, (
+    assert "5 of 21" in out, (
         "someone deciding whether to trust this needs the coverage fraction, "
         "and it should move as rules get ported"
     )


### PR DESCRIPTION
## Summary
Port `RequiredResultTypeMissing` (R015) to the TypeScript language backend so `mcp-migrate check` can flag hand-rolled JSON-RPC servers that omit the required `resultType` field.

## Motivation
Issue #44 asks for a TypeScript port of R015. The Python rule already exists; TypeScript servers are the majority of MCP codebases, so this rule needs the same SDK exemption and hand-rolled envelope detection on the TS side.

## Changes
- Add `languages = ("python", "typescript")` and split `check()` into `_check_python` / `_check_ts`
- Exempt projects that import `@modelcontextprotocol/sdk` (SDK stamps `resultType` on serialized results)
- Detect hand-rolled envelopes via `search_wire` on `jsonrpc` keys (quoted and unquoted) and MCP method string literals
- Keep the permissive raw-text `resultType` presence check (comment mention silences the rule, same as Python)
- Add TypeScript tests: legacy hand-rolled server, migrated server, comment-only mention, quoted `jsonrpc` key, SDK exemption
- Update partial-coverage denominator to `5 of 21`

## Tests
```bash
python3 -m pytest tests/test_typescript.py -q
python3 -m pytest -q
```
All 194 tests pass.

## Notes
- Uses `search_wire` (not `search_code`) for wire-protocol string literals, consistent with R001/R006
- Project-wide SDK exemption matches the Python rule's behavior

Fixes #44