### PR TITLE
feat(rules): port R016 (cacheable result metadata) to TypeScript

### DIFF
--- a/src/mcp_migrate/rules/r016_cacheable_result_required.py
+++ b/src/mcp_migrate/rules/r016_cacheable_result_required.py
@@ -38,6 +38,33 @@ CACHE_META_MENTION_RX = re.compile(r"ttlMs|cacheScope")
 # cache metadata at all.
 CACHE_HINT_CONFIG_RX = re.compile(r"\bcache_hints\s*=|\bCacheHint\s*\(")
 
+# --- TypeScript -----------------------------------------------------------
+#
+# Low-level servers register list/read handlers with request schemas or wire
+# method names. search_code for the schema identifiers; search_wire for the
+# method string literals in setRequestHandler calls.
+TS_CACHEABLE_HANDLER_RX = (
+    r"setRequestHandler\s*\(\s*(?:ListTools|ListPrompts|ListResources|"
+    r"ReadResource|ListResourceTemplates)RequestSchema\b"
+)
+TS_CACHEABLE_METHOD_RX = (
+    r"setRequestHandler\s*\(\s*"
+    r"[\"'](?:tools/list|prompts/list|resources/list|resources/read|"
+    r"resources/templates/list)[\"']"
+)
+
+# Server-level hints are configured once on construction:
+#   new McpServer({ ... }, { cacheHints: { 'tools/list': { ttlMs, cacheScope }}})
+# Per-resource hints use cacheHint: on registerResource. Either satisfies
+# the rule project-wide -- scanning handler files for literal ttlMs/cacheScope
+# would miss a server that configured hints correctly in a different file.
+TS_CACHE_HINT_CONFIG_RX = re.compile(r"\bcacheHints\b|\bcacheHint\s*:")
+
+MESSAGE = (
+    "This file implements a list/read handler but neither `ttlMs` nor "
+    "`cacheScope` appears in it."
+)
+
 
 # Downgraded from "breaking" after auditing real servers: ttlMs/cacheScope
 # are brand-new required fields introduced by this same spec revision, so
@@ -61,8 +88,14 @@ class CacheableResultMetadataMissing(Rule):
         "per handler: Server(cache_hints={method: CacheHint(...)}). Without hints "
         "the SDK emits no cache metadata at all."
     )
+    languages = ("python", "typescript")
 
     def check(self, project: Project) -> list[Finding]:
+        if project.language == "typescript":
+            return self._check_ts(project)
+        return self._check_python(project)
+
+    def _check_python(self, project: Project) -> list[Finding]:
         # Cache hints are registered once on the server, so this is a
         # project-wide question, not a per-file one.
         if any(project.search_code(CACHE_HINT_CONFIG_RX.pattern)):
@@ -75,9 +108,23 @@ class CacheableResultMetadataMissing(Rule):
             if CACHE_META_MENTION_RX.search(f.text):
                 continue
             seen_files.add(f.path)
-            out.append(self.finding(
-                "This file implements a list/read handler but neither `ttlMs` nor "
-                "`cacheScope` appears in it.",
-                f, line, text,
-            ))
+            out.append(self.finding(MESSAGE, f, line, text))
+        return out
+
+    def _check_ts(self, project: Project) -> list[Finding]:
+        if any(project.search_code(TS_CACHE_HINT_CONFIG_RX.pattern)):
+            return []
+        handler_hits: dict[object, tuple[int, str]] = {}
+        for f, line, text in project.search_code(TS_CACHEABLE_HANDLER_RX):
+            handler_hits.setdefault(f.path, (line, text))
+        for f, line, text in project.search_wire(TS_CACHEABLE_METHOD_RX):
+            handler_hits.setdefault(f.path, (line, text))
+        out: list[Finding] = []
+        for path, (line, text) in sorted(
+            handler_hits.items(), key=lambda item: (str(item[0]), item[1][0])
+        ):
+            f = next(ff for ff in project.files if ff.path == path)
+            if CACHE_META_MENTION_RX.search(f.text):
+                continue
+            out.append(self.finding(MESSAGE, f, line, text))
         return out

--- a/tests/test_typescript.py
+++ b/tests/test_typescript.py
@@ -24,6 +24,9 @@ from mcp_migrate.rules.r001_session_id_removed import SessionIdRemoved
 from mcp_migrate.rules.r003_routing_headers import MissingRoutingHeaders
 from mcp_migrate.rules.r005_extensions import NoExtensionsDeclared
 from mcp_migrate.rules.r006_sse_transport_deprecated import DeprecatedSSETransport
+from mcp_migrate.rules.r016_cacheable_result_required import (
+    CacheableResultMetadataMissing,
+)
 from mcp_migrate.scan import load_project
 
 LEGACY_TS = """\
@@ -231,6 +234,94 @@ const config = {
     assert NoExtensionsDeclared().check(project) == []
 
 
+# --- R016: ttlMs/cacheScope on list/read results -------------------------
+
+def test_r016_finds_missing_cache_metadata_in_typescript(tmp_path):
+    code = """\
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js";
+
+const server = new Server({ name: "demo", version: "1.0.0" });
+
+server.setRequestHandler(ListToolsRequestSchema, async () => {
+  return { tools: [] };
+});
+"""
+    project = load_project(_write(tmp_path, "server.ts", code)).for_language("typescript")
+    findings = CacheableResultMetadataMissing().check(project)
+    assert len(findings) == 1
+    assert findings[0].line == 6
+    assert "ttlMs" in findings[0].message
+
+
+def test_r016_stays_silent_on_migrated_typescript_server(tmp_path):
+    code = """\
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js";
+
+const server = new Server({ name: "demo", version: "1.0.0" });
+
+server.setRequestHandler(ListToolsRequestSchema, async () => {
+  return { tools: [], ttlMs: 300_000, cacheScope: "server" };
+});
+"""
+    project = load_project(_write(tmp_path, "server.ts", code)).for_language("typescript")
+    assert CacheableResultMetadataMissing().check(project) == []
+
+
+def test_r016_ignores_cache_metadata_named_only_in_comment(tmp_path):
+    code = """\
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js";
+
+// The transport layer adds ttlMs and cacheScope when cacheHints are set.
+server.setRequestHandler(ListToolsRequestSchema, async () => {
+  return { tools: [] };
+});
+"""
+    project = load_project(_write(tmp_path, "server.ts", code)).for_language("typescript")
+    # Comment mentions ttlMs/cacheScope but handler still lacks them -- the
+    # rule uses a generous presence check, so a comment counts as handled.
+    assert CacheableResultMetadataMissing().check(project) == []
+
+
+def test_r016_is_satisfied_by_cache_hints_configured_on_the_server(tmp_path):
+    code = """\
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+
+const server = new McpServer(
+  { name: "demo", version: "1.0.0" },
+  {
+    cacheHints: {
+      "tools/list": { ttlMs: 60_000, cacheScope: "public" },
+    },
+  }
+);
+
+server.registerTool("noop", { description: "no-op" }, async () => ({
+  content: [{ type: "text", text: "ok" }],
+}));
+"""
+    project = load_project(_write(tmp_path, "server.ts", code)).for_language("typescript")
+    assert CacheableResultMetadataMissing().check(project) == []
+
+
+def test_r016_finds_wire_method_handler_without_cache_metadata(tmp_path):
+    code = """\
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+
+const server = new Server({ name: "demo", version: "1.0.0" });
+
+server.setRequestHandler("tools/list", async () => {
+  return { tools: [] };
+});
+"""
+    project = load_project(_write(tmp_path, "server.ts", code)).for_language("typescript")
+    findings = CacheableResultMetadataMissing().check(project)
+    assert len(findings) == 1
+    assert findings[0].line == 5
+
+
 # --- the language split itself --------------------------------------------
 
 def test_python_rules_never_see_typescript_files(tmp_path):
@@ -279,7 +370,7 @@ def test_partial_coverage_is_stated_with_a_denominator(tmp_path, capsys):
     # Collapse whitespace: rich wraps at terminal width and will happily
     # split the fraction across two lines.
     out = " ".join(capsys.readouterr().out.split())
-    assert "4 of 21" in out, (
+    assert "5 of 21" in out, (
         "someone deciding whether to trust this needs the coverage fraction, "
         "and it should move as rules get ported"
     )


### PR DESCRIPTION
## Summary

Port rule R016 () to the TypeScript language backend so `mcp-migrate check` can flag list/read handlers that omit `ttlMs`/`cacheScope` when no server-level cache hints are configured.

## Motivation

Issue #45 asks for a TypeScript port of R016. List/read MCP results now require cache metadata per SEP-2549; TypeScript servers using low-level `setRequestHandler` need the same advisory detection Python servers already get.

## Changes

- Add `languages = ("python", "typescript")` and split `check()` into `_check_python` / `_check_ts`
- TypeScript handler detection via `setRequestHandler` + list/read request schemas or wire method strings (`tools/list`, etc.)
- Project-wide exemption when `cacheHints` or per-resource `cacheHint:` appears anywhere in the project
- Per-file generous presence check for `ttlMs` / `cacheScope` (mirrors Python)
- Five new tests in `tests/test_typescript.py`; update partial-coverage denominator to 5 of 21

## Tests

```
python3 -m pytest tests/ -q
195 passed
```

## Notes

- Follows the same `search_code` / `search_wire` split as other TS rule ports
- `McpServer` + `registerTool` only (no explicit `setRequestHandler`) is intentionally out of scope for per-file handler detection, same class of gap as Python FastMCP functional registration; server-level `cacheHints` exemption still applies

Fixes #45