### PR TITLE
feat(rules): port R020 (Dynamic Client Registration) to TypeScript

### DIFF
--- a/src/mcp_migrate/rules/r020_dynamic_client_registration_deprecated.py
+++ b/src/mcp_migrate/rules/r020_dynamic_client_registration_deprecated.py
@@ -1,5 +1,3 @@
-import re
-
 from .base import Finding, Project, Rule
 
 # All three are specific enough to MCP/OAuth client-registration code to
@@ -10,8 +8,15 @@ from .base import Finding, Project, Rule
 # A generic "register a client" method in an unrelated CRM/billing app
 # wouldn't spell it exactly `register_client`, so this is precise enough
 # for `deprecated` (the lower-stakes severity this item calls for).
-DCR_CODE_RX = re.compile(
+PY_DCR_CODE_RX = (
     r"\bRegisterClientRequest\b|\bDynamicClientRegistration\b|\bregister_client\b"
+)
+
+# TypeScript uses camelCase for the SDK auth hook (`registerClient` in
+# @modelcontextprotocol/sdk/client/auth.ts) where Python spells it
+# `register_client`. The type names are the same across languages.
+TS_DCR_CODE_RX = (
+    r"\bRegisterClientRequest\b|\bDynamicClientRegistration\b|\bregisterClient\b"
 )
 
 
@@ -24,15 +29,18 @@ class DynamicClientRegistrationDeprecated(Rule):
         "RFC 7591 Dynamic Client Registration is deprecated in favour of Client ID "
         "Metadata Documents. Plan a migration to CIMD for onboarding new OAuth clients."
     )
+    languages = ("python", "typescript")
+
+    MESSAGE = (
+        "Uses RFC 7591 Dynamic Client Registration, deprecated in favour of "
+        "Client ID Metadata Documents."
+    )
 
     def check(self, project: Project) -> list[Finding]:
-        out: list[Finding] = []
+        pattern = TS_DCR_CODE_RX if project.language == "typescript" else PY_DCR_CODE_RX
         # search_code: a comment/docstring mentioning dynamic client
         # registration isn't a real dependency on it.
-        for f, line, text in project.search_code(DCR_CODE_RX.pattern):
-            out.append(self.finding(
-                "Uses RFC 7591 Dynamic Client Registration, deprecated in favour of "
-                "Client ID Metadata Documents.",
-                f, line, text,
-            ))
-        return out
+        return [
+            self.finding(self.MESSAGE, f, line, text)
+            for f, line, text in project.search_code(pattern)
+        ]

--- a/tests/test_typescript.py
+++ b/tests/test_typescript.py
@@ -24,6 +24,9 @@ from mcp_migrate.rules.r001_session_id_removed import SessionIdRemoved
 from mcp_migrate.rules.r003_routing_headers import MissingRoutingHeaders
 from mcp_migrate.rules.r005_extensions import NoExtensionsDeclared
 from mcp_migrate.rules.r006_sse_transport_deprecated import DeprecatedSSETransport
+from mcp_migrate.rules.r020_dynamic_client_registration_deprecated import (
+    DynamicClientRegistrationDeprecated,
+)
 from mcp_migrate.scan import load_project
 
 LEGACY_TS = """\
@@ -217,6 +220,81 @@ const server = new Server(
     assert "extensions" in findings[0].message
 
 
+# --- R020: Dynamic Client Registration deprecated -----------------------
+
+def test_r020_finds_register_client_in_typescript(tmp_path):
+    code = """\
+import type { OAuthClientMetadata } from "@modelcontextprotocol/sdk/types.js";
+
+export async function registerClient(
+  authorizationServerUrl: URL,
+  metadata: OAuthClientMetadata,
+) {
+  const registrationUrl = new URL("/register", authorizationServerUrl);
+  const res = await fetch(registrationUrl, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(metadata),
+  });
+  return res.json();
+}
+"""
+    project = load_project(_write(tmp_path, "auth.ts", code)).for_language("typescript")
+    findings = DynamicClientRegistrationDeprecated().check(project)
+    assert len(findings) == 1
+    assert findings[0].line == 3
+
+
+def test_r020_finds_register_client_request_type_in_typescript(tmp_path):
+    code = """\
+import type { RegisterClientRequest } from "@modelcontextprotocol/sdk/types.js";
+
+export function buildRequest(): RegisterClientRequest {
+  return { redirect_uris: ["https://app.example/callback"] };
+}
+"""
+    project = load_project(_write(tmp_path, "auth.ts", code)).for_language("typescript")
+    findings = DynamicClientRegistrationDeprecated().check(project)
+    assert len(findings) >= 1
+    assert any("RegisterClientRequest" in (f.snippet or "") for f in findings)
+
+
+def test_r020_stays_silent_on_migrated_typescript_auth(tmp_path):
+    # CIMD: client metadata is hosted at a well-known URL, no /register call.
+    code = """\
+import type { OAuthClientMetadata } from "@modelcontextprotocol/sdk/types.js";
+
+export const CLIENT_METADATA: OAuthClientMetadata = {
+  client_id: "https://app.example/.well-known/oauth-client",
+  redirect_uris: ["https://app.example/callback"],
+};
+"""
+    project = load_project(_write(tmp_path, "auth.ts", code)).for_language("typescript")
+    assert DynamicClientRegistrationDeprecated().check(project) == []
+
+
+def test_r020_ignores_dynamic_client_registration_named_only_in_comment(tmp_path):
+    code = """\
+// Legacy note: we used registerClient against the /register endpoint.
+// RegisterClientRequest and DynamicClientRegistration are deprecated.
+export const AUTH_MODE = "cimd";
+"""
+    project = load_project(_write(tmp_path, "docs.ts", code)).for_language("typescript")
+    assert DynamicClientRegistrationDeprecated().check(project) == []
+
+
+def test_r020_does_not_fire_on_unrelated_register_method(tmp_path):
+    code = """\
+class CRM {
+  registerNewCustomer(info: Record<string, unknown>) {
+    return { customer_id: 1, ...info };
+  }
+}
+"""
+    project = load_project(_write(tmp_path, "billing.ts", code)).for_language("typescript")
+    assert DynamicClientRegistrationDeprecated().check(project) == []
+
+
 def test_r005_stays_silent_on_non_mcp_typescript(tmp_path):
     # capabilities: {} is an ordinary property name. Without an SDK import
     # this is not an MCP server, so the rule stays quiet.
@@ -279,7 +357,7 @@ def test_partial_coverage_is_stated_with_a_denominator(tmp_path, capsys):
     # Collapse whitespace: rich wraps at terminal width and will happily
     # split the fraction across two lines.
     out = " ".join(capsys.readouterr().out.split())
-    assert "4 of 21" in out, (
+    assert "5 of 21" in out, (
         "someone deciding whether to trust this needs the coverage fraction, "
         "and it should move as rules get ported"
     )


### PR DESCRIPTION
## What kind of PR is this?

- [ ] Cookbook recipe -- adds/fills in a file in `cookbook/`
- [x] Rule -- adds/changes a rule in `src/mcp_migrate/rules/`
- [ ] Fixer -- adds/changes a fixer in `src/mcp_migrate/fixers/`
- [ ] Board entry -- adds/updates a `registry/servers/*.yaml` file
- [ ] Something else

## Summary

Port R020 (`DynamicClientRegistrationDeprecated`) to the TypeScript language backend. The rule now detects RFC 7591 Dynamic Client Registration usage in `.ts` files via `search_code`, matching `RegisterClientRequest`, `DynamicClientRegistration`, and the camelCase SDK hook `registerClient`.

## Motivation

Fixes #49. Most MCP servers are TypeScript; without this port, R020 only runs on Python files and misses the majority of real DCR usage.

## Changes

- Add `languages = ("python", "typescript")` to `DynamicClientRegistrationDeprecated`
- Split Python (`register_client`) and TypeScript (`registerClient`) identifier patterns
- Add five TypeScript tests: legacy `registerClient`, `RegisterClientRequest` type usage, CIMD-migrated auth, comment-only mentions, unrelated register methods
- Update partial-coverage denominator assertion to `5 of 21`

## Rule checklist

- [x] `severity` is `breaking`, `deprecated`, or `advisory`
- [x] `spec_ref` names the spec section or SEP the rule enforces
- [ ] Fixtures added under `tests/fixtures/<rule-id>/` (inline tmp_path tests used, same as R001/R003/R005/R006)
- [x] At least one test added and passing (`pytest`)
- [x] `mcp-migrate rules` lists the new rule

## Tests

```bash
python3 -m pytest tests/test_typescript.py -q   # 27 passed
python3 -m pytest -q                           # 195 passed
```

## Notes

- Uses `search_code` (not `search_wire`) because all signals are code identifiers, mirroring the Python implementation.
- `/register` endpoint URLs in string literals are intentionally not matched (same as Python).
- Reviewed by composer-2.5 subagent before submission.

Fixes #49