### PR TITLE
perf: hoist R015 TypeScript scans

### DIFF
--- a/src/mcp_migrate/rules/r015_result_type_required.py
+++ b/src/mcp_migrate/rules/r015_result_type_required.py
@@ -137,33 +137,29 @@ class RequiredResultTypeMissing(Rule):
     def _check_ts(self, project: Project) -> list[Finding]:
         if _ts_sdk_owns_serialization(project):
             return []
+        # search_wire keeps string literals ("jsonrpc", "tools/list")
+        # and drops comments -- a README-style comment naming the
+        # protocol is not a hand-rolled envelope. Scan the project once
+        # per pattern, rather than once per file in the loop below.
+        jsonrpc_paths = {
+            f.path for f, _line, _text in project.search_wire(TS_JSONRPC_ENVELOPE_RX.pattern)
+        }
+        jsonrpc_paths.update(
+            f.path for f, _line, _text in project.search_wire(JSONRPC_ENVELOPE_RX.pattern)
+        )
+        method_hits: dict[object, tuple[int, str]] = {}
+        for f, line, text in project.search_wire(MCP_METHOD_NAME_RX.pattern):
+            method_hits.setdefault(f.path, (line, text))
+
         out: list[Finding] = []
-        seen_files = set()
         for f in project.files:
             if RESULT_TYPE_MENTION_RX.search(f.text):
                 continue
-            if f.path in seen_files:
+            if f.path not in jsonrpc_paths:
                 continue
-            # search_wire keeps string literals ("jsonrpc", "tools/list")
-            # and drops comments -- a README-style comment naming the
-            # protocol is not a hand-rolled envelope.
-            has_jsonrpc = any(
-                ff.path == f.path
-                for ff, _line, _text in project.search_wire(TS_JSONRPC_ENVELOPE_RX.pattern)
-            ) or any(
-                ff.path == f.path
-                for ff, _line, _text in project.search_wire(JSONRPC_ENVELOPE_RX.pattern)
-            )
-            if not has_jsonrpc:
-                continue
-            method_hit: tuple[int, str] | None = None
-            for ff, line, text in project.search_wire(MCP_METHOD_NAME_RX.pattern):
-                if ff.path == f.path:
-                    method_hit = (line, text)
-                    break
+            method_hit = method_hits.get(f.path)
             if method_hit is None:
                 continue
             line, text = method_hit
-            seen_files.add(f.path)
             out.append(self.finding(self.MESSAGE, f, line, text))
         return out


### PR DESCRIPTION
## What changed

Hoist the R015 TypeScript `search_wire` scans out of the per-file loop and bucket matches by path. This avoids rescanning the entire project for every file.

## Why

The previous implementation called `project.search_wire(...)` inside the loop over `project.files`, making the rule quadratic in project file count. The new implementation scans each pattern once while preserving the first method hit and existing file-order behavior.

## Validation

- `uv run pytest tests/test_rules.py tests/test_regressions.py tests/test_typescript.py -q` — 150 passed
- `uv run pytest -q` — 223 passed
- `git diff --check` — passed

Closes #67,