### PR TITLE
docs(cookbook): fill R003 routing headers recipe

### DIFF
--- a/cookbook/14-routing-headers.md
+++ b/cookbook/14-routing-headers.md
@@ -1,6 +1,3 @@
-<!-- STUB: rule/spec filled in, before/after/gotchas still needed. See
-     .github/GOOD_FIRST_ISSUES.md for the ready-to-file issue for this one. -->
-
 # Required `Mcp-Method` / `Mcp-Name` routing headers
 
 - **Rule:** [R003](../src/mcp_migrate/rules/r003_routing_headers.py)
@@ -20,22 +17,98 @@ hand-rolled HTTP client speaking MCP's wire protocol directly (not through
 an SDK that already sets these) that skips them gets rejected by anything
 enforcing the new transport requirement.
 
+The failure mode is a 4xx from a proxy or gateway that enforces the
+Streamable HTTP header contract, not a JSON-RPC error in the body. Your
+request may never reach the MCP server at all.
+
 ## Before
 
-TODO: a hand-rolled `.post()` call sending a raw JSON-RPC envelope
-(`{"method": "tools/call", ...}`) without setting `Mcp-Method`/`Mcp-Name`.
+```python
+import httpx
+
+_client = httpx.Client(timeout=5.0)
+
+
+def notify_downstream(tool_name: str, arguments: dict) -> None:
+    """Hand-roll a JSON-RPC POST to an internal MCP relay."""
+    resp = _client.post(
+        "https://hooks.internal.example.com/mcp-events",
+        json={
+            "jsonrpc": "2.0",
+            "method": "tools/call",
+            "params": {"name": tool_name, "arguments": arguments},
+        },
+    )
+    resp.raise_for_status()
+```
 
 ## After
 
-TODO: the same call with both headers set.
+```python
+import httpx
+
+_client = httpx.Client(timeout=5.0)
+
+
+def notify_downstream(tool_name: str, arguments: dict) -> None:
+    """Hand-roll a JSON-RPC POST to an internal MCP relay."""
+    resp = _client.post(
+        "https://hooks.internal.example.com/mcp-events",
+        headers={
+            "Mcp-Method": "tools/call",
+            "Mcp-Name": tool_name,
+        },
+        json={
+            "jsonrpc": "2.0",
+            "method": "tools/call",
+            "params": {"name": tool_name, "arguments": arguments},
+        },
+    )
+    resp.raise_for_status()
+```
+
+TypeScript looks the same in spirit:
+
+```typescript
+const res = await fetch(url, {
+  method: "POST",
+  headers: {
+    "Content-Type": "application/json",
+    "Mcp-Method": "tools/call",
+    "Mcp-Name": "my-tool",
+  },
+  body: JSON.stringify({ method: "tools/call", params: payload }),
+});
+```
 
 ## Gotchas
 
-TODO: this rule is deliberately conservative about what counts as "hand-rolling
-MCP transport" versus "wrapping some unrelated backend REST API in the same
-file" -- worth walking through the actual gating logic
-(`_imports_mcp`/`MCP_METHOD_RX`) with a concrete example of each so a reader
-understands why one file trips this and a similar-looking one doesn't.
+- **`Mcp-Name` is not required on every POST.** Only `tools/call`,
+  `resources/read`, and `prompts/get` carry a name a proxy can route on.
+  A hand-rolled `tools/list` or `initialize` call needs `Mcp-Method` but
+  not `Mcp-Name` -- flagging its absence was an early R003 bug.
+- **R003 is deliberately conservative about what counts as "hand-rolling
+  MCP transport."** The rule only fires when the file plausibly speaks
+  MCP's own wire protocol: it imports `mcp` (but not `mcp.server.fastmcp`
+  or `mcp.server.transport_security`, where the SDK owns transport
+  entirely), or it contains a literal like `tools/call` / `jsonrpc`. A
+  plain REST client for Jira or Confluence in the same project does not
+  trip this rule even though it also calls `.post()` -- that combination
+  was mcp-atlassian's worst false positive (19 hits before the rule was
+  tightened), which is why severity is `advisory`, not `breaking`.
+- **FastMCP + a backend REST API in one file is not a finding.** A tool
+  that imports only `mcp.server.fastmcp` and separately `.post()`s to its
+  own search API is doing its job, not re-implementing MCP transport.
+- **Header presence is checked per file, not per project.** Setting
+  `Mcp-Method` in one module does not excuse a hand-rolled POST in another
+  file that omits it.
+- **You need an HTTP client import.** Without `requests`, `httpx`, or
+  `aiohttp` in the project, R003 stays silent -- a bare `.post(` on
+  something else (an ORM, a queue) is unrelated noise.
+- **Prefer the SDK when you can.** If you are not deliberately crafting
+  JSON-RPC envelopes, move the call behind
+  `StreamableHTTPServerTransport` / the official MCP SDK client instead of
+  maintaining header names by hand.
 
 ## Spec link
 

--- a/cookbook/README.md
+++ b/cookbook/README.md
@@ -34,6 +34,7 @@ Every recipe follows [`_TEMPLATE.md`](_TEMPLATE.md):
 | 03 | [HTTP+SSE to Streamable HTTP](03-sse-to-streamable-http.md) | R006 | R006 (review) |
 | 04 | [subscribe/unsubscribe to subscriptions/listen](04-subscribe-to-subscriptions-listen.md) | R013 | none |
 | 05 | [resultType and cache metadata on results](05-result-type-and-cache-metadata.md) | R015, R016 | none |
+| 14 | [Required Mcp-Method / Mcp-Name routing headers](14-routing-headers.md) | R003 | none |
 
 ## Stubs -- open slots
 
@@ -53,7 +54,6 @@ ready-to-file issue for each.
 | 11 | [Tasks moved to an extension, polling replaces blocking result](11-tasks-polling.md) | R019 |
 | 12 | [Dynamic Client Registration deprecated](12-dynamic-client-registration-deprecated.md) | R020 |
 | 13 | [JSON Schema 2020-12 required](13-json-schema-2020-12.md) | R021 |
-| 14 | [Required Mcp-Method / Mcp-Name routing headers](14-routing-headers.md) | R003 |
 | 15 | [Deterministic tools/list ordering](15-deterministic-tool-ordering.md) | R004 |
 | 16 | [extensions map on ServerCapabilities](16-extensions-map.md) | R005 |
 | 17 | [Trace context propagation from _meta](17-trace-context-propagation.md) | R008 |


### PR DESCRIPTION
## Summary

Complete the stub cookbook recipe for R003 (required `Mcp-Method` / `Mcp-Name` routing headers on Streamable HTTP).

## Motivation

Fixes #9. The stub had rule metadata and a one-line "what broke" but was missing the worked before/after examples and gotchas that make a cookbook recipe useful.

## Changes

- Fill `cookbook/14-routing-headers.md` with Python and TypeScript before/after examples
- Document gotchas: advisory severity, mcp-atlassian false-positive gating (`_imports_mcp` / `MCP_METHOD_RX`), `Mcp-Name` scope, per-file header checks, FastMCP exclusion
- Move recipe 14 from the stubs table to "Filed so far" in `cookbook/README.md`

## Tests

Cookbook-only change (no Python code). Verified R003 regression fixtures still pass:

```
pytest tests/test_regressions.py::test_plain_rest_post_with_no_mcp_surface_does_not_fire_r003 \
       tests/test_regressions.py::test_r003_still_fires_when_file_hand_rolls_jsonrpc_payload \
       tests/test_regressions.py::test_fastmcp_import_alone_does_not_satisfy_the_mcp_surface_gate
# 3 passed
```

## Notes

Reviewed against `r003_routing_headers.py` and the regression fixtures (`webhook.py`, `jira_client.py`, `fastmcp_wrapper_no_mcp_surface/server.py`).

Fixes #9