### PR TITLE
fix: ignore comment-only R016 metadata mentions

### DIFF
--- a/src/mcp_migrate/rules/r016_cacheable_result_required.py
+++ b/src/mcp_migrate/rules/r016_cacheable_result_required.py
@@ -11,11 +11,9 @@ CACHEABLE_HANDLER_RX = re.compile(
     r"list_resource_templates)\s*\("
 )
 
-# Presence check, deliberately raw text (same permissive direction as
-# r005_extensions.py / r015_result_type_required.py): a mention anywhere in
-# the file is enough to count the metadata as handled, because a wrong
-# "still missing" (breaking) claim costs far more than a generous read of
-# "present" does.
+# Presence check keeps string literals but ignores comments and docstrings:
+# a metadata field in a response or a string-built response counts, while a
+# prose mention must not silence a real finding.
 CACHE_META_MENTION_RX = re.compile(r"ttlMs|cacheScope")
 
 # The other, and more likely, way these fields get onto the wire.
@@ -100,12 +98,15 @@ class CacheableResultMetadataMissing(Rule):
         # project-wide question, not a per-file one.
         if any(project.search_code(CACHE_HINT_CONFIG_RX.pattern)):
             return []
+        cache_meta_paths = {
+            f.path for f, _line, _text in project.search_wire(CACHE_META_MENTION_RX.pattern)
+        }
         out: list[Finding] = []
         seen_files = set()
         for f, line, text in project.search_code(CACHEABLE_HANDLER_RX.pattern):
             if f.path in seen_files:
                 continue
-            if CACHE_META_MENTION_RX.search(f.text):
+            if f.path in cache_meta_paths:
                 continue
             seen_files.add(f.path)
             out.append(self.finding(MESSAGE, f, line, text))
@@ -119,12 +120,15 @@ class CacheableResultMetadataMissing(Rule):
             handler_hits.setdefault(f.path, (line, text))
         for f, line, text in project.search_wire(TS_CACHEABLE_METHOD_RX):
             handler_hits.setdefault(f.path, (line, text))
+        cache_meta_paths = {
+            f.path for f, _line, _text in project.search_wire(CACHE_META_MENTION_RX.pattern)
+        }
         out: list[Finding] = []
         for path, (line, text) in sorted(
             handler_hits.items(), key=lambda item: (str(item[0]), item[1][0])
         ):
             f = next(ff for ff in project.files if ff.path == path)
-            if CACHE_META_MENTION_RX.search(f.text):
+            if f.path in cache_meta_paths:
                 continue
             out.append(self.finding(MESSAGE, f, line, text))
         return out

--- a/tests/fixtures/clean_server/server.py
+++ b/tests/fixtures/clean_server/server.py
@@ -9,6 +9,7 @@ answer any request.
 from __future__ import annotations
 
 from mcp.server import Server
+from mcp.server.caching import CacheHint
 from mcp.server.streamable_http import StreamableHTTPServerTransport
 from mcp.types import (
     ServerCapabilities,
@@ -20,7 +21,10 @@ from .store import NoteStore
 
 store = NoteStore()
 
-server = Server("notes-server")
+server = Server(
+    "notes-server",
+    cache_hints={"tools/" + "list": CacheHint(ttl_ms=60_000)},
+)
 
 capabilities = ServerCapabilities(
     tools=ToolsCapability(list_changed=True),
@@ -37,8 +41,6 @@ async def list_tools() -> list[Tool]:
         Tool(name="add_note", description="Append a note under a handle."),
         Tool(name="clear_notes", description="Wipe the notes under a handle."),
     ]
-    # SEP-2549 CacheableResult: the transport layer attaches ttlMs and
-    # cacheScope metadata to this tools/list response before it goes out.
     return sorted(tools, key=lambda t: t.name)
 
 

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -444,6 +444,21 @@ def test_r016_still_fires_when_no_cache_metadata_exists_anywhere(tmp_path):
     )
 
 
+def test_r016_does_not_treat_a_python_comment_as_cache_metadata(tmp_path):
+    (tmp_path / "server.py").write_text(
+        "from mcp.server import Server\n"
+        "\n"
+        "app = Server('demo')\n"
+        "\n"
+        "# The transport adds ttlMs and cacheScope later.\n"
+        "@app.list_tools()\n"
+        "async def list_tools():\n"
+        "    return []\n"
+    )
+    project = load_project(tmp_path)
+    assert CacheableResultMetadataMissing().check(project)
+
+
 # --- 8. R007 must not fire on the Anthropic Messages API -------------------
 #
 # Found by scanning the official registry, not by reading code. R007's

--- a/tests/test_typescript.py
+++ b/tests/test_typescript.py
@@ -535,7 +535,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
     assert CacheableResultMetadataMissing().check(project) == []
 
 
-def test_r016_ignores_cache_metadata_named_only_in_comment(tmp_path):
+def test_r016_finds_missing_cache_metadata_when_comment_mentions_it(tmp_path):
     code = """\
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js";
@@ -543,11 +543,26 @@ import { ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js";
 // The transport layer adds ttlMs and cacheScope when cacheHints are set.
 server.setRequestHandler(ListToolsRequestSchema, async () => {
   return { tools: [] };
-});
+    });
 """
     project = load_project(_write(tmp_path, "server.ts", code)).for_language("typescript")
-    # Comment mentions ttlMs/cacheScope but handler still lacks them -- the
-    # rule uses a generous presence check, so a comment counts as handled.
+    # A comment must not count as metadata in the handler's response.
+    findings = CacheableResultMetadataMissing().check(project)
+    assert len(findings) == 1
+
+
+def test_r016_accepts_cache_metadata_in_a_string_built_response(tmp_path):
+    code = '''\
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js";
+
+const server = new Server({ name: "demo", version: "1.0.0" });
+
+server.setRequestHandler(ListToolsRequestSchema, async () => {
+  return JSON.parse('{"tools": [], "ttlMs": 300000, "cacheScope": "server"}');
+});
+'''
+    project = load_project(_write(tmp_path, "server.ts", code)).for_language("typescript")
     assert CacheableResultMetadataMissing().check(project) == []
 
 


### PR DESCRIPTION
## What changed

Fix R016 so comments and docstrings mentioning `ttlMs` or `cacheScope` do not silence a real missing-metadata finding.

The rule now uses `search_wire` to collect metadata mentions that occur in code or string literals while excluding prose. This is applied to both Python and TypeScript branches.

Updated regression coverage verifies:

- Python comments still produce an R016 finding
- TypeScript comments still produce an R016 finding
- metadata in a string-built response is accepted
- the clean fixture configures real cache hints instead of relying on a comment

## Validation

- `uv run pytest -q` — 225 passed
- `git diff --check` — passed

Closes #66,