### PR TITLE
feat: port R017 resource-not-found detection to TypeScript

### DIFF
--- a/src/mcp_migrate/rules/r017_resource_not_found_code_changed.py
+++ b/src/mcp_migrate/rules/r017_resource_not_found_code_changed.py
@@ -12,6 +12,13 @@ RESOURCE_NOT_FOUND_RX = re.compile(
     r"(?=.*-32002\b)(?=.*(?:resource|not[_ ]?found|notfound))", re.IGNORECASE
 )
 
+# TypeScript commonly spells the context as a camelCase identifier or keeps
+# it inside an error message. The same line-level positive evidence keeps the
+# generic numeric code from matching unrelated sentinels.
+TS_RESOURCE_NOT_FOUND_RX = (
+    r"(?=.*-32002\b)(?=.*(?:resource|not[_ -]?found))"
+)
+
 
 class ResourceNotFoundCodeChanged(Rule):
     id = "R017"
@@ -22,8 +29,20 @@ class ResourceNotFoundCodeChanged(Rule):
         "The resource-not-found error code changed from -32002 to -32602 (Invalid "
         "params). Update whatever raises or checks for -32002 in this context."
     )
+    languages = ("python", "typescript")
 
     def check(self, project: Project) -> list[Finding]:
+        if project.language == "typescript":
+            return [
+                self.finding(
+                    "-32002 for resource-not-found is the old code; 2026-07-28 uses -32602.",
+                    f, line, text,
+                )
+                for f, line, text in project.search_wire(
+                    TS_RESOURCE_NOT_FOUND_RX, flags=re.IGNORECASE
+                )
+            ]
+
         out: list[Finding] = []
         # Raw text, not search_code: the qualifying context is as likely
         # to be a trailing comment ("# resource not found") as it is to be

--- a/tests/test_typescript.py
+++ b/tests/test_typescript.py
@@ -30,6 +30,9 @@ from mcp_migrate.rules.r015_result_type_required import RequiredResultTypeMissin
 from mcp_migrate.rules.r016_cacheable_result_required import (
     CacheableResultMetadataMissing,
 )
+from mcp_migrate.rules.r017_resource_not_found_code_changed import (
+    ResourceNotFoundCodeChanged,
+)
 from mcp_migrate.rules.r020_dynamic_client_registration_deprecated import (
     DynamicClientRegistrationDeprecated,
 )
@@ -170,6 +173,37 @@ const server = new Server({ name: "my-server", version: "1.0.0" }, { capabilitie
 """
     project = load_project(_write(tmp_path, "server.ts", code)).for_language("typescript")
     assert RequiredResultTypeMissing().check(project) == []
+
+
+def test_r017_finds_old_resource_not_found_code_in_typescript(tmp_path):
+    code = """\
+export function readResource(uri: string) {
+  throw new Error(`resource not found (-32002): ${uri}`);
+}
+"""
+    project = load_project(_write(tmp_path, "server.ts", code)).for_language("typescript")
+    findings = ResourceNotFoundCodeChanged().check(project)
+    assert len(findings) == 1
+    assert findings[0].line == 2
+
+
+def test_r017_stays_silent_on_migrated_typescript_server(tmp_path):
+    code = """\
+export function readResource(uri: string) {
+  throw new Error(`resource not found (-32602): ${uri}`);
+}
+"""
+    project = load_project(_write(tmp_path, "server.ts", code)).for_language("typescript")
+    assert ResourceNotFoundCodeChanged().check(project) == []
+
+
+def test_r017_ignores_old_code_named_only_in_typescript_comment(tmp_path):
+    code = """\
+// The old resource not found code was -32002; this server uses -32602.
+export const RESOURCE_NOT_FOUND_CODE = -32602;
+"""
+    project = load_project(_write(tmp_path, "server.ts", code)).for_language("typescript")
+    assert ResourceNotFoundCodeChanged().check(project) == []
 
 
 def test_neither_fires_on_a_migrated_typescript_server(tmp_path):


### PR DESCRIPTION
## Summary

- port R017 to the TypeScript backend
- detect the legacy `-32002` resource-not-found code in TypeScript code and string literals
- keep migrated `-32602` code and comment-only mentions silent

## Validation

- `uv run pytest tests/test_typescript.py tests/test_regressions.py -q` (102 passed)
- `uv run pytest -q` (226 passed)
- `git diff --check`

Closes #46
