### PR TITLE
fix(r004): replace fixed-window scoping with brace-depth scan (fixes #65)

### DIFF
--- a/src/mcp_migrate/rules/r004_tool_ordering.py
+++ b/src/mcp_migrate/rules/r004_tool_ordering.py
@@ -46,8 +46,43 @@ def _body_bounds(lines: list[str], line_no: int) -> tuple[int, int]:
     return body_start, end
 
 
-TS_HANDLER_RX = re.compile(r"ListToolsRequestSchema|listTools|tools/list", re.IGNORECASE)
+TS_HANDLER_RX = re.compile(r"ListToolsRequestSchema|listTools|tools/list")
 TS_SORT_RX = re.compile(r"\.(?:sort|toSorted)\s*\(|\bsorted\s*\(|\bsortBy\b|\borderBy\b", re.IGNORECASE)
+
+
+def _ts_body_bounds(
+    lines: list[str], line_no: int, spans: list[tuple[tuple[int, int], tuple[int, int]]] | None
+) -> tuple[int, int]:
+    """Return (body_start, body_end) 0-based bounds for the TypeScript handler
+    block starting at 1-based `line_no` using brace-depth scanning.
+
+    Scans forward from `line_no` to find the opening '{' of the handler body,
+    then tracks '{' and '}' braces (skipping any inside comments or strings via
+    `spans`) until depth returns to 0. If no matching closing brace is found,
+    falls back to min(len(lines), line_no + 40).
+    """
+    depth = 0
+    found_first_brace = False
+    body_start = line_no
+
+    for cur_line_no in range(line_no, len(lines) + 1):
+        line = lines[cur_line_no - 1]
+        for col, char in enumerate(line):
+            if spans is not None and _in_content_span(cur_line_no, col, spans):
+                continue
+            if char == "{":
+                if not found_first_brace:
+                    found_first_brace = True
+                    body_start = cur_line_no
+                depth += 1
+            elif char == "}" and found_first_brace:
+                depth -= 1
+                if depth == 0:
+                    return body_start, cur_line_no
+
+    if not found_first_brace:
+        return line_no, min(len(lines), line_no + 40)
+    return body_start, len(lines)
 
 
 class NondeterministicToolOrder(Rule):
@@ -110,6 +145,7 @@ class NondeterministicToolOrder(Rule):
         for f in project.files:
             covered: list[tuple[int, int]] = []
             prose = project._prose_spans_for(f)
+            content_spans = project._spans_for(f)
             for line_no, line in enumerate(f.lines, start=1):
                 if line.strip().startswith("import "):
                     continue
@@ -121,7 +157,7 @@ class NondeterministicToolOrder(Rule):
                 if any(start <= line_no <= end for start, end in covered):
                     continue
 
-                end_line = min(len(f.lines), line_no + 40)
+                body_start, end_line = _ts_body_bounds(f.lines, line_no, content_spans)
                 covered.append((line_no, end_line))
 
                 window = "\n".join(f.lines[line_no - 1:end_line])
@@ -131,3 +167,4 @@ class NondeterministicToolOrder(Rule):
                     "Tools are returned without an explicit sort.", f, line_no, line.strip(),
                 ))
         return out
+

--- a/tests/test_typescript.py
+++ b/tests/test_typescript.py
@@ -671,6 +671,65 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
     assert NondeterministicToolOrder().check(project) == []
 
 
+def test_r004_ignores_unrelated_sort_outside_handler_body(tmp_path):
+    code = """\
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js";
+
+const server = new Server({ name: "example", version: "1.0.0" });
+server.setRequestHandler(ListToolsRequestSchema, async () => {
+  return {
+    tools: [
+      { name: "b_tool", description: "B" },
+      { name: "a_tool", description: "A" }
+    ]
+  };
+});
+
+// Unrelated sort 10 lines later
+const items = getItems();
+items.sort((a, b) => a.id - b.id);
+"""
+    project = load_project(_write(tmp_path, "server.ts", code)).for_language("typescript")
+    findings = NondeterministicToolOrder().check(project)
+    assert len(findings) == 1
+    assert findings[0].line == 5
+
+
+def test_r004_scopes_long_handlers_correctly_past_40_lines(tmp_path):
+    padding = "\n".join(f"  const step{i} = {i};" for i in range(45))
+    code = f"""\
+import {{ Server }} from "@modelcontextprotocol/sdk/server/index.js";
+import {{ ListToolsRequestSchema }} from "@modelcontextprotocol/sdk/types.js";
+
+const server = new Server({{ name: "example", version: "1.0.0" }});
+server.setRequestHandler(ListToolsRequestSchema, async () => {{
+{padding}
+  const tools = [{{ name: "b" }}, {{ name: "a" }}];
+  return {{ tools: tools.sort((a, b) => a.name.localeCompare(b.name)) }};
+}});
+"""
+    project = load_project(_write(tmp_path, "server.ts", code)).for_language("typescript")
+    assert NondeterministicToolOrder().check(project) == []
+
+
+def test_r004_handles_closing_braces_inside_strings_and_template_literals(tmp_path):
+    code = """\
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js";
+
+const server = new Server({ name: "example", version: "1.0.0" });
+server.setRequestHandler(ListToolsRequestSchema, async () => {
+  const msg = `Closing brace inside string: }`;
+  const tools = [{ name: "b" }, { name: "a" }];
+  return { tools: tools.sort((a, b) => a.name.localeCompare(b.name)) };
+});
+"""
+    project = load_project(_write(tmp_path, "server.ts", code)).for_language("typescript")
+    assert NondeterministicToolOrder().check(project) == []
+
+
+
 def test_partial_coverage_is_stated_with_a_denominator(tmp_path, capsys):
     main(["check", str(_write(tmp_path, "transport.ts", LEGACY_TS))])
     # Collapse whitespace: rich wraps at terminal width and will happily


### PR DESCRIPTION
…#65)

## What kind of PR is this?

- [ ] Cookbook recipe -- adds/fills in a file in `cookbook/`
- [ ] Rule -- adds/changes a rule in `src/mcp_migrate/rules/`
- [ ] Fixer -- adds/changes a fixer in `src/mcp_migrate/fixers/`
- [ ] Board entry -- adds/updates a `registry/servers/*.yaml` file
- [ ] Something else

## Cookbook recipe

- [ ] Follows `cookbook/_TEMPLATE.md` (Rule/Fixer/Severity/Spec, What broke,
      Before, After, Gotchas, Spec link)
- [ ] Row added to (or moved out of "Stubs" in) `cookbook/README.md`

## Rule

- [ ] `severity` is `breaking`, `deprecated`, or `advisory`
- [ ] `spec_ref` names the spec section or SEP the rule enforces
- [ ] Fixtures added under `tests/fixtures/<rule-id>/`
- [ ] At least one test added and passing (`pytest`)
- [ ] `mcp-migrate rules` lists the new rule

## Fixer

- [ ] `rule_id` matches an existing rule's `id`
- [ ] `confidence` is `safe` only if the transformation cannot change
      behavior beyond what the rule flags -- otherwise `review`
- [ ] Ambiguous shapes are left unchanged (`self.unchanged(source)`), not
      guessed at -- ideally with a fixture proving the backoff
- [ ] A round-trip/idempotency test: running the fixer twice changes
      nothing the second time
- [ ] `mcp-migrate fixers` lists the new fixer

## Board entry

- [ ] Generated with `mcp-migrate entry --repo owner/name`
- [ ] `notes:` edited to a real, one-sentence description
- [ ] `name` matches the filename

## Anything else reviewers should know?

This PR complete #65 by replacing the fixed 40-line look-ahead window in TypeScript `R004` with a brace-depth (`{`/`}`) scanner.

- **Brace-Depth Scanner (`_ts_body_bounds`)**: Scans forward from the handler match to find the opening `{` of the handler body and tracks `{` / `}` depth (skipping any braces inside comments or string/template literals using `project._spans_for(f)`).
- **Case Sensitivity**: Removed `re.IGNORECASE` flag from `TS_HANDLER_RX` to align with TypeScript SDK name matching.
- **Unit Tests Added (`tests/test_typescript.py`)**:
  1. `test_r004_ignores_unrelated_sort_outside_handler_body`: Verifies an unrelated `.sort()` 10 lines after the handler is not incorrectly counted.
  2. `test_r004_scopes_long_handlers_correctly_past_40_lines`: Verifies long handlers (> 40 lines) with a `.sort()` past line 40 are correctly recognized.
  3. `test_r004_handles_closing_braces_inside_strings_and_template_literals`: Verifies template literals containing `}` do not prematurely terminate handler body scoping.

All 226 tests pass 100% green.

Fixes #65