### PR TITLE
R016: Route ttlMs/cacheScope mention check through content spans (#66)

### DIFF
--- a/src/mcp_migrate/rules/r016_cacheable_result_required.py
+++ b/src/mcp_migrate/rules/r016_cacheable_result_required.py
@@ -11,11 +11,10 @@ CACHEABLE_HANDLER_RX = re.compile(
     r"list_resource_templates)\s*\("
 )
 
-# Presence check, deliberately raw text (same permissive direction as
-# r005_extensions.py / r015_result_type_required.py): a mention anywhere in
-# the file is enough to count the metadata as handled, because a wrong
-# "still missing" (breaking) claim costs far more than a generous read of
-# "present" does.
+# Presence check: a mention anywhere in code or string literals in the file is
+# enough to count the metadata as handled, because a wrong "still missing"
+# (breaking) claim costs far more than a generous read of "present" does.
+# Searched via search_wire to ignore comments and docstrings.
 CACHE_META_MENTION_RX = re.compile(r"ttlMs|cacheScope")
 
 # The other, and more likely, way these fields get onto the wire.
@@ -100,12 +99,15 @@ class CacheableResultMetadataMissing(Rule):
         # project-wide question, not a per-file one.
         if any(project.search_code(CACHE_HINT_CONFIG_RX.pattern)):
             return []
+        files_with_mention = {
+            f.path for f, _, _ in project.search_wire(CACHE_META_MENTION_RX.pattern)
+        }
         out: list[Finding] = []
         seen_files = set()
         for f, line, text in project.search_code(CACHEABLE_HANDLER_RX.pattern):
             if f.path in seen_files:
                 continue
-            if CACHE_META_MENTION_RX.search(f.text):
+            if f.path in files_with_mention:
                 continue
             seen_files.add(f.path)
             out.append(self.finding(MESSAGE, f, line, text))
@@ -114,6 +116,9 @@ class CacheableResultMetadataMissing(Rule):
     def _check_ts(self, project: Project) -> list[Finding]:
         if any(project.search_code(TS_CACHE_HINT_CONFIG_RX.pattern)):
             return []
+        files_with_mention = {
+            f.path for f, _, _ in project.search_wire(CACHE_META_MENTION_RX.pattern)
+        }
         handler_hits: dict[object, tuple[int, str]] = {}
         for f, line, text in project.search_code(TS_CACHEABLE_HANDLER_RX):
             handler_hits.setdefault(f.path, (line, text))
@@ -123,8 +128,8 @@ class CacheableResultMetadataMissing(Rule):
         for path, (line, text) in sorted(
             handler_hits.items(), key=lambda item: (str(item[0]), item[1][0])
         ):
-            f = next(ff for ff in project.files if ff.path == path)
-            if CACHE_META_MENTION_RX.search(f.text):
+            if path in files_with_mention:
                 continue
+            f = next(ff for ff in project.files if ff.path == path)
             out.append(self.finding(MESSAGE, f, line, text))
         return out

--- a/tests/fixtures/clean_server/server.py
+++ b/tests/fixtures/clean_server/server.py
@@ -9,6 +9,7 @@ answer any request.
 from __future__ import annotations
 
 from mcp.server import Server
+from mcp.server.caching import CacheHint
 from mcp.server.streamable_http import StreamableHTTPServerTransport
 from mcp.types import (
     ServerCapabilities,
@@ -20,7 +21,8 @@ from .store import NoteStore
 
 store = NoteStore()
 
-server = Server("notes-server")
+cache_hints = {"list_tools": CacheHint(ttl_ms=60000)}
+server = Server("notes-server", cache_hints=cache_hints)
 
 capabilities = ServerCapabilities(
     tools=ToolsCapability(list_changed=True),

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -444,6 +444,29 @@ def test_r016_still_fires_when_no_cache_metadata_exists_anywhere(tmp_path):
     )
 
 
+def test_r016_flags_cache_metadata_named_only_in_python_comment(tmp_path):
+    # A comment mentioning ttlMs or cacheScope does not satisfy the rule.
+    (tmp_path / "server.py").write_text(
+        "# The transport layer adds ttlMs and cacheScope when cache_hints are set.\n"
+        "@app.list_tools()\n"
+        "async def list_tools():\n"
+        "    return []\n"
+    )
+    project = load_project(tmp_path)
+    assert len(CacheableResultMetadataMissing().check(project)) == 1
+
+
+def test_r016_suppressed_by_cache_metadata_in_python_code(tmp_path):
+    # A code mention of ttlMs or cacheScope satisfies the rule.
+    (tmp_path / "server.py").write_text(
+        "@app.list_tools()\n"
+        "async def list_tools():\n"
+        "    return [{'ttlMs': 5000}]\n"
+    )
+    project = load_project(tmp_path)
+    assert CacheableResultMetadataMissing().check(project) == []
+
+
 # --- 8. R007 must not fire on the Anthropic Messages API -------------------
 #
 # Found by scanning the official registry, not by reading code. R007's

--- a/tests/test_typescript.py
+++ b/tests/test_typescript.py
@@ -535,7 +535,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
     assert CacheableResultMetadataMissing().check(project) == []
 
 
-def test_r016_ignores_cache_metadata_named_only_in_comment(tmp_path):
+def test_r016_flags_cache_metadata_named_only_in_comment(tmp_path):
     code = """\
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js";
@@ -546,9 +546,9 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
 });
 """
     project = load_project(_write(tmp_path, "server.ts", code)).for_language("typescript")
-    # Comment mentions ttlMs/cacheScope but handler still lacks them -- the
-    # rule uses a generous presence check, so a comment counts as handled.
-    assert CacheableResultMetadataMissing().check(project) == []
+    # Comment mentions ttlMs/cacheScope but handler still lacks them in code --
+    # prose mentions do not satisfy the rule.
+    assert len(CacheableResultMetadataMissing().check(project)) == 1
 
 
 def test_r016_is_satisfied_by_cache_hints_configured_on_the_server(tmp_path):


### PR DESCRIPTION
Fixes #66

## Context
 previously matched against raw , which included comments and docstrings. A handler file that genuinely lacked cache metadata was falsely excused if a comment anywhere in the file happened to mention  or .

## Changes Made
- Updated  and  in  to route  through , restricting presence checks to code and string literal spans while ignoring prose/comments/docstrings.
- Updated : flipped  to assert a finding is reported when metadata is mentioned only in comments.
- Updated : added Python equivalent tests ( and ).
- Configured  on  fixture so  satisfies R016 in code.

## Verification
- Ran full test suite via pytest: .