### PR TITLE
fix(r007): add TODO-annotation fixer for deprecated core features

### DIFF
--- a/src/mcp_migrate/fixers/r007_deprecated_features.py
+++ b/src/mcp_migrate/fixers/r007_deprecated_features.py
@@ -1,0 +1,94 @@
+"""Fixer for R007 -- Roots, Sampling and Logging deprecated as core capabilities.
+
+There is no mechanical replacement for any of these: Roots wants resource
+URIs, Sampling wants a multi-round-trip design, Logging wants an extension.
+So this fixer does the one thing that is safe without understanding the
+surrounding code -- leave a loud TODO exactly where the human needs to look,
+and comment out only lines where doing so cannot break syntax (single-line
+statements, not block openers, not the opening line of a multiline call).
+Confidence "review": every flagged site still needs a human pass.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from .base import Fixer, FixResult
+
+SPEC_URL = "https://modelcontextprotocol.io/specification/draft/changelog"
+COOKBOOK = "cookbook/18-roots-sampling-logging-deprecated.md"
+
+# Mirrors r007_deprecated_features.FEATURES -- same patterns, same precision.
+FEATURES: dict[str, str] = {
+    r"\broots/list\b|list_roots|RootsCapability": "Roots",
+    r"sampling/createMessage|SamplingCapability|\bsession\.create_message\b"
+    r"|\bCreateMessageRequest\b|\bCreateMessageResult\b": "Sampling",
+    r"notifications/message|LoggingCapability|set_logging_level": "Logging",
+}
+FEATURE_RX = tuple((re.compile(p), name) for p, name in FEATURES.items())
+
+
+def _todo(feature: str) -> str:
+    return (
+        f"# TODO(mcp-migrate): {feature} is deprecated as a core capability; "
+        f"see {SPEC_URL} and {COOKBOOK}"
+    )
+
+
+def _feature_on_line(line: str) -> str | None:
+    for rx, name in FEATURE_RX:
+        if rx.search(line):
+            return name
+    return None
+
+
+def _safe_to_comment_out(line: str) -> bool:
+    """Commenting out must not leave a dangling suite or multiline expression."""
+    stripped = line.rstrip("\n").rstrip()
+    if stripped.endswith(":"):
+        return False
+    if stripped.endswith(("(", "[", "{", "\\")):
+        return False
+    return True
+
+
+class DeprecatedCoreFeaturesFixer(Fixer):
+    rule_id = "R007"
+    title = "Annotate deprecated Roots/Sampling/Logging usage with a TODO"
+    confidence = "review"
+
+    def fix(self, source: str, path: Path) -> FixResult:
+        lines = source.splitlines(keepends=True)
+        out: list[str] = []
+        changes: list[str] = []
+
+        for i, raw_line in enumerate(lines, start=1):
+            stripped = raw_line.lstrip(" \t")
+            already_commented = stripped.startswith("#")
+            feature = None if already_commented else _feature_on_line(raw_line)
+
+            if feature:
+                indent = raw_line[: len(raw_line) - len(stripped)]
+                newline = "\n" if raw_line.endswith("\n") else ""
+                todo = _todo(feature)
+                body = stripped.rstrip("\n")
+
+                if not (out and out[-1].strip(" \t\n") == todo):
+                    out.append(f"{indent}{todo}{newline}")
+                if _safe_to_comment_out(raw_line):
+                    out.append(f"{indent}# {body}{newline}")
+                    changes.append(
+                        f"line {i}: commented out deprecated {feature} usage, added TODO"
+                    )
+                else:
+                    out.append(raw_line)
+                    changes.append(
+                        f"line {i}: added TODO for deprecated {feature} usage"
+                    )
+            else:
+                out.append(raw_line)
+
+        new_text = "".join(out)
+        if not changes:
+            return self.unchanged(source)
+        return self.result(new_text, changes)

--- a/tests/test_fixers.py
+++ b/tests/test_fixers.py
@@ -39,7 +39,7 @@ def fix(name: str, source: str, path: str = "server.py"):
 # ---------------------------------------------------------------------------
 
 def test_ships_a_fixer_for_every_rule_the_task_calls_out():
-    assert {"R001", "R004", "R005", "R006", "R017"} <= FIXER_RULE_IDS
+    assert {"R001", "R004", "R005", "R006", "R007", "R017"} <= FIXER_RULE_IDS
 
 
 def test_every_fixer_has_a_valid_confidence_and_metadata():
@@ -268,6 +268,75 @@ def test_r006_idempotent():
     )
     once = fix("SseTransportFixer", before)
     twice = fix("SseTransportFixer", once.text)
+    assert twice.changed is False
+    assert twice.text == once.text
+
+
+# ---------------------------------------------------------------------------
+# R007 -- Roots / Sampling / Logging deprecated
+# ---------------------------------------------------------------------------
+
+R007_ROOTS_BEFORE = (
+    "from mcp.types import ServerCapabilities\n\n"
+    "caps = ServerCapabilities(roots=RootsCapability())\n"
+)
+R007_ROOTS_AFTER = (
+    "from mcp.types import ServerCapabilities\n\n"
+    "# TODO(mcp-migrate): Roots is deprecated as a core capability; see "
+    "https://modelcontextprotocol.io/specification/draft/changelog and "
+    "cookbook/18-roots-sampling-logging-deprecated.md\n"
+    "# caps = ServerCapabilities(roots=RootsCapability())\n"
+)
+
+
+def test_r007_comments_out_roots_capability_and_leaves_a_todo():
+    result = fix("DeprecatedCoreFeaturesFixer", R007_ROOTS_BEFORE)
+    assert result.changed
+    assert result.text == R007_ROOTS_AFTER
+    assert FIXERS["DeprecatedCoreFeaturesFixer"].confidence == "review"
+    ast.parse(result.text)
+
+
+def test_r007_adds_todo_without_commenting_multiline_sampling_opener():
+    before = (
+        "async def summarize(ctx):\n"
+        "    result = await ctx.session.create_message(\n"
+        "        messages=[], max_tokens=100,\n"
+        "    )\n"
+        "    return result\n"
+    )
+    result = fix("DeprecatedCoreFeaturesFixer", before)
+    assert result.changed
+    assert "TODO(mcp-migrate): Sampling is deprecated" in result.text
+    assert "result = await ctx.session.create_message(" in result.text
+    assert "#     result = await ctx.session.create_message(" not in result.text
+    ast.parse(result.text)
+
+
+def test_r007_comments_out_logging_capability_declaration():
+    before = "from mcp.types import LoggingCapability, ServerCapabilities\n\n"
+    before += "caps = ServerCapabilities(logging=LoggingCapability())\n"
+    result = fix("DeprecatedCoreFeaturesFixer", before)
+    assert result.changed
+    assert "TODO(mcp-migrate): Logging is deprecated" in result.text
+    assert "# caps = ServerCapabilities(logging=LoggingCapability())" in result.text
+    ast.parse(result.text)
+
+
+def test_r007_never_touches_anthropic_client_wrappers():
+    before = (
+        "class ChatAnthropic:\n"
+        "    async def _create_message(self, **params):\n"
+        "        return await client.messages.create(**params)\n"
+    )
+    result = fix("DeprecatedCoreFeaturesFixer", before)
+    assert result.changed is False
+    assert result.text == before
+
+
+def test_r007_idempotent():
+    once = fix("DeprecatedCoreFeaturesFixer", R007_ROOTS_BEFORE)
+    twice = fix("DeprecatedCoreFeaturesFixer", once.text)
     assert twice.changed is False
     assert twice.text == once.text
 


### PR DESCRIPTION
## Summary

Add a `review`-confidence fixer for R007 that annotates Roots, Sampling, and Logging usage with a `# TODO(mcp-migrate): ...` comment pointing at the spec changelog and `cookbook/18-roots-sampling-logging-deprecated.md`, following the same pattern as the R001 session-id fixer.

## Motivation

R007 flags dependencies on deprecated core capabilities, but there is no mechanical migration path — the human must decide how to replace Roots with resource URIs, Sampling with multi-round-trip flows, or Logging with an extension. A TODO-annotation fixer gives a loud, precise pointer without pretending to auto-migrate fuzzy behavior.

Fixes #17

## Changes

- New `DeprecatedCoreFeaturesFixer` in `src/mcp_migrate/fixers/r007_deprecated_features.py`
  - Uses the same regex patterns as the R007 rule (including `\bsession\.create_message\b` to avoid Anthropic client false positives)
  - Comments out single-line statements; multiline call openers get a TODO only (no comment-out) to preserve valid syntax
  - Skips block openers and already-commented lines; idempotent on re-run
- Five tests in `tests/test_fixers.py` covering Roots, Sampling, Logging, Anthropic-wrapper non-match, and idempotency
- Updated fixer discovery assertion to include R007

## Tests

```
python3 -m pytest tests/test_fixers.py -v   # 37/37 pass
python3 -m pytest -q                         # 228/228 pass
```

## Notes

- Confidence is `review` (not `safe`) — every annotated site still needs a human pass
- Cookbook stub at `cookbook/18-roots-sampling-logging-deprecated.md` still says "Fixer: none"; happy to update in a follow-up if desired