### PR TITLE
feat(rules): port R007 (deprecated core features) to TypeScript

### DIFF
--- a/src/mcp_migrate/rules/r007_deprecated_features.py
+++ b/src/mcp_migrate/rules/r007_deprecated_features.py
@@ -1,3 +1,5 @@
+import re
+
 from .base import Finding, Project, Rule
 
 # Every pattern here has to be unambiguously MCP. A bare `create_message`
@@ -20,6 +22,65 @@ FEATURES = {
     r"notifications/message|LoggingCapability|set_logging_level": ("Logging", "Logging moves out of core; use an extension."),
 }
 
+# --- TypeScript -----------------------------------------------------------
+#
+# Three signals per feature, because the three kinds of evidence need three
+# different search modes and three different levels of caution:
+#
+#   * SDK type/schema names (`ListRootsRequestSchema`, `SamplingCapability`)
+#     -- code, and distinctive enough to stand alone. `\w*` suffix because
+#     the TS SDK exports both the Zod schema and the inferred type
+#     (`CreateMessageRequest` / `CreateMessageRequestSchema`), and
+#     `\bCreateMessageRequest\b` cannot match inside the longer name.
+#   * the SDK method calls (`.listRoots(`, `.createMessage(`,
+#     `.sendLoggingMessage(`) -- code, but gated on MCP context, see
+#     TS_OWNER/TS_MCP_SURFACE_RX below.
+#   * the JSON-RPC method names (`roots/list`, `sampling/createMessage`,
+#     `notifications/message`) -- string literals, so they need
+#     `search_wire`; `search_code` discards every string token and would
+#     never find them.
+#
+# The `owner.` qualifier is the TypeScript spelling of the Python rule's
+# `session.` anchor, and exists for exactly the same reason: an unanchored
+# `createMessage` collides with the wrappers people write around chat APIs.
+# TS servers reach sampling through the protocol object rather than a
+# request context -- `server.createMessage(...)` on the low-level `Server`,
+# `mcpServer.server.createMessage(...)` on `McpServer` -- so the owner is a
+# server/client/session-shaped name, matched with a `\w*` prefix so
+# `mcpServer.` and `this.client.` qualify too.
+TS_OWNER = r"\b\w*(?:[Ss]erver|[Cc]lient|[Ss]ession)\."
+
+# Is this file MCP at all? Same gate r011_ping_removed.py uses, and for the
+# same reason: `createMessage` on some `chatClient` in a file that never
+# touches MCP is not MCP Sampling, and a wrong `deprecated` verdict costs a
+# maintainer's trust while a missed one costs a little visibility.
+TS_MCP_SURFACE_RX = re.compile(
+    r"@modelcontextprotocol|tools/call|tools/list|resources/read|prompts/get|jsonrpc",
+    re.IGNORECASE,
+)
+
+# (feature, advice, SDK names, gated method call, JSON-RPC method name)
+TS_FEATURES = (
+    (
+        "Roots", "Use resource URIs instead.",
+        r"\bListRootsRequest\w*|\bListRootsResult\w*|\bRootsCapability\b",
+        TS_OWNER + r"listRoots\s*\(",
+        r"roots/list",
+    ),
+    (
+        "Sampling", "Sampling is deprecated; plan a migration.",
+        r"\bCreateMessageRequest\w*|\bCreateMessageResult\w*|\bSamplingCapability\b",
+        TS_OWNER + r"createMessage\s*\(",
+        r"sampling/createMessage",
+    ),
+    (
+        "Logging", "Logging moves out of core; use an extension.",
+        r"\bLoggingCapability\b|\bLoggingMessageNotification\w*",
+        TS_OWNER + r"sendLoggingMessage\s*\(",
+        r"notifications/message",
+    ),
+)
+
 
 class DeprecatedCoreFeatures(Rule):
     id = "R007"
@@ -27,8 +88,14 @@ class DeprecatedCoreFeatures(Rule):
     severity = "deprecated"
     spec_ref = "Roots, Sampling and Logging deprecated"
     fix = "These stay in the spec for at least 12 months, then leave. Start moving now."
+    languages = ("python", "typescript")
 
     def check(self, project: Project) -> list[Finding]:
+        if project.language == "typescript":
+            return self._check_ts(project)
+        return self._check_python(project)
+
+    def _check_python(self, project: Project) -> list[Finding]:
         out: list[Finding] = []
         for pattern, (name, advice) in FEATURES.items():
             # search_code: a comment/docstring mentioning "sampling" or
@@ -37,3 +104,36 @@ class DeprecatedCoreFeatures(Rule):
             for f, line, text in project.search_code(pattern):
                 out.append(self.finding(f"{name} is deprecated. {advice}", f, line, text))
         return out
+
+    def _check_ts(self, project: Project) -> list[Finding]:
+        out: list[Finding] = []
+        seen: set[tuple[str, int, str]] = set()
+        mcp_paths = {f.path for f in project.files if TS_MCP_SURFACE_RX.search(f.text)}
+
+        for name, advice, code_rx, owned_rx, wire_rx in TS_FEATURES:
+            message = f"{name} is deprecated. {advice}"
+            hits = [
+                (f, line, text, True)
+                for f, line, text in project.search_code(code_rx)
+            ] + [
+                (f, line, text, False)
+                for f, line, text in project.search_code(owned_rx)
+            ] + [
+                (f, line, text, True)
+                for f, line, text in project.search_wire(wire_rx)
+            ]
+            for f, line, text, ungated in hits:
+                if not ungated and f.path not in mcp_paths:
+                    continue
+                # Keyed by feature as well as location: one import line can
+                # legitimately name two different deprecated features, and
+                # those are two findings. The same feature twice on one line
+                # (`const r: CreateMessageResult = await server.createMessage(...)`)
+                # is one.
+                key = (str(f.path), line, name)
+                if key in seen:
+                    continue
+                seen.add(key)
+                out.append(self.finding(message, f, line, text))
+
+        return sorted(out, key=lambda x: (str(x.path or ""), x.line or 0))

--- a/tests/test_typescript.py
+++ b/tests/test_typescript.py
@@ -25,6 +25,7 @@ from mcp_migrate.rules.r003_routing_headers import MissingRoutingHeaders
 from mcp_migrate.rules.r004_tool_ordering import NondeterministicToolOrder
 from mcp_migrate.rules.r005_extensions import NoExtensionsDeclared
 from mcp_migrate.rules.r006_sse_transport_deprecated import DeprecatedSSETransport
+from mcp_migrate.rules.r007_deprecated_features import DeprecatedCoreFeatures
 from mcp_migrate.rules.r011_ping_removed import PingRemoved
 from mcp_migrate.rules.r015_result_type_required import RequiredResultTypeMissing
 from mcp_migrate.rules.r016_cacheable_result_required import (
@@ -500,6 +501,126 @@ export function handle(message: string) {
 """
     project = load_project(_write(tmp_path, "game.ts", code)).for_language("typescript")
     assert PingRemoved().check(project) == []
+# --- R007: deprecated core features (Roots / Sampling / Logging) ---------
+
+def test_r007_finds_the_sdk_names_in_typescript(tmp_path):
+    code = """\
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import {
+  ListRootsRequestSchema,
+  CreateMessageRequestSchema,
+  LoggingMessageNotificationSchema,
+} from "@modelcontextprotocol/sdk/types.js";
+"""
+    project = load_project(_write(tmp_path, "server.ts", code)).for_language("typescript")
+    findings = DeprecatedCoreFeatures().check(project)
+    named = {f.line: f.message for f in findings}
+    assert "Roots" in named[3]
+    assert "Sampling" in named[4]
+    assert "Logging" in named[5]
+    assert len(findings) == 3
+
+
+def test_r007_finds_the_wire_names_in_typescript(tmp_path):
+    # JSON-RPC method names only ever exist inside string literals, so
+    # this is the half search_code would never find.
+    code = """\
+export const DEPRECATED = [
+  "roots/list",
+  "sampling/createMessage",
+  "notifications/message",
+];
+"""
+    project = load_project(_write(tmp_path, "methods.ts", code)).for_language("typescript")
+    findings = DeprecatedCoreFeatures().check(project)
+    assert [f.line for f in findings] == [2, 3, 4]
+
+
+def test_r007_finds_sampling_through_the_server_object(tmp_path):
+    code = """\
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+
+const mcpServer = new McpServer({ name: "demo", version: "1.0.0" });
+
+export async function summarise(text: string) {
+  return mcpServer.server.createMessage({
+    messages: [{ role: "user", content: { type: "text", text } }],
+    maxTokens: 100,
+  });
+}
+"""
+    project = load_project(_write(tmp_path, "sample.ts", code)).for_language("typescript")
+    findings = DeprecatedCoreFeatures().check(project)
+    assert len(findings) == 1
+    assert findings[0].line == 6
+    assert "Sampling" in findings[0].message
+
+
+def test_r007_does_not_fire_on_a_chat_wrapper_without_mcp_context(tmp_path):
+    # The Python rule's whole false-positive story: a `createMessage`
+    # wrapper around a chat API has nothing to do with MCP Sampling. In a
+    # file that never mentions MCP, this stays quiet.
+    code = """\
+import Anthropic from "@anthropic-ai/sdk";
+
+export class ChatClient {
+  constructor(private client: Anthropic) {}
+
+  async createMessage(prompt: string) {
+    return this.client.messages.create({
+      model: "claude-sonnet-5",
+      max_tokens: 1024,
+      messages: [{ role: "user", content: prompt }],
+    });
+  }
+}
+
+const chatClient = new ChatClient(new Anthropic());
+await chatClient.createMessage("hello");
+"""
+    project = load_project(_write(tmp_path, "chat.ts", code)).for_language("typescript")
+    assert DeprecatedCoreFeatures().check(project) == []
+
+
+def test_r007_charges_one_line_once_per_feature(tmp_path):
+    # Two signals for Sampling on one line is one dependency on Sampling.
+    code = """\
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+
+const result: CreateMessageResult = await server.createMessage(params);
+"""
+    project = load_project(_write(tmp_path, "sample.ts", code)).for_language("typescript")
+    findings = DeprecatedCoreFeatures().check(project)
+    assert len(findings) == 1
+    assert findings[0].line == 3
+
+
+def test_r007_stays_silent_on_migrated_typescript_server(tmp_path):
+    code = """\
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js";
+
+const server = new Server({ name: "demo", version: "1.0.0" });
+
+server.setRequestHandler(ListToolsRequestSchema, async () => ({ tools: [] }));
+"""
+    project = load_project(_write(tmp_path, "server.ts", code)).for_language("typescript")
+    assert DeprecatedCoreFeatures().check(project) == []
+
+
+def test_r007_ignores_deprecated_features_named_only_in_comments(tmp_path):
+    code = """\
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+
+// Migration note: we dropped roots/list, sampling/createMessage and
+// notifications/message. RootsCapability and SamplingCapability are gone.
+/** server.createMessage() and server.listRoots() are no longer called. */
+export const NOTE = 1;
+"""
+    project = load_project(_write(tmp_path, "docs.ts", code)).for_language("typescript")
+    assert DeprecatedCoreFeatures().check(project) == []
+
+
 # --- R016: ttlMs/cacheScope on list/read results -------------------------
 
 def test_r016_finds_missing_cache_metadata_in_typescript(tmp_path):


### PR DESCRIPTION
Fixes #36.

Ports **R007** (`Depends on a deprecated core feature (Roots / Sampling / Logging)`, `deprecated`) to TypeScript. `languages = ("python", "typescript")`, `check()` splits on `project.language`, and the Python path moves into `_check_python` unchanged — same layout as the R001/R006/R011 ports.

## Three kinds of evidence, three search modes

| Signal | Search mode | Gated? |
| --- | --- | --- |
| `ListRootsRequest\w*`, `CreateMessageRequest\w*`, `SamplingCapability`, `RootsCapability`, `LoggingCapability`, `LoggingMessageNotification\w*` | `search_code` | no — these names are unambiguously MCP |
| `.listRoots(`, `.createMessage(`, `.sendLoggingMessage(` | `search_code` | **yes** — see below |
| `roots/list`, `sampling/createMessage`, `notifications/message` | `search_wire` | no |

The wire names only ever exist as string literals, so `search_wire` is required — `search_code` drops every string token and would find none of them. The `\w*` suffixes are there because TypeScript ships both the Zod schema and the inferred type, and `\bCreateMessageRequest\b` cannot match inside `CreateMessageRequestSchema`.

## The gating is the part worth reviewing

This rule already has a false-positive story, recorded in its own comments: a bare `create_message` matched every wrapper around the Anthropic Messages API, and browser-use took three `deprecated` findings for its Anthropic client. Python fixed it by anchoring to `session.`.

TypeScript can't use that anchor — TS servers reach sampling through the protocol object, not a request context:

```ts
server.createMessage({ ... })            // low-level Server
mcpServer.server.createMessage({ ... })  // McpServer
```

So the anchor here is a server/client/session-shaped owner with a `\w*` prefix (so `mcpServer.` and `this.client.` qualify). That is a **weaker** filter than Python's, so the method-call half additionally requires the file to show some MCP surface at all — an SDK import or an MCP wire method name — which is the same gate `r011_ping_removed.py` puts on its `"ping"` dispatch. A `chatClient.createMessage()` wrapper in a file that never mentions MCP stays silent, and there's a test asserting exactly that against a realistic `@anthropic-ai/sdk` wrapper.

## Finding keys

Keyed by `(file, line, feature)`: one import line naming two deprecated features is two findings, while `const r: CreateMessageResult = await server.createMessage(...)` is one.

## Tests

Seven new tests in `tests/test_typescript.py`: SDK names, wire names, sampling through the server object, the un-gated chat wrapper staying silent, the one-line-one-feature dedupe, a migrated server, and a file naming everything only in comments/JSDoc.

Full suite: **230 passed** (223 on `main` + 7). Verified end to end — `mcp-migrate check` on a TypeScript server now reports R007, and the coverage line moves to `10 of 21`.

---

One thing I noticed but deliberately left alone, since it's outside this issue: on the **Python** side the `roots/list`, `sampling/createMessage` and `notifications/message` alternatives go through `search_code`, which discards string tokens — so those three alternatives can never match in Python, and the feature is only ever caught by its identifier siblings (`list_roots`, `SamplingCapability`, ...). Happy to open a separate issue for it if that's useful.