### PR TITLE
fix(r014): add TODO-annotation fixer for SSE resumability removal

### DIFF
--- a/src/mcp_migrate/fixers/r014_sse_resumability.py
+++ b/src/mcp_migrate/fixers/r014_sse_resumability.py
@@ -1,0 +1,96 @@
+"""Fixer for R014 -- SSE resumability (Last-Event-ID) removed from the transport.
+
+There is no mechanical replacement for stream resumability: a dropped
+connection is just dropped now, and the client re-issues a fresh request.
+So this fixer does the one thing that is safe without understanding the
+surrounding code -- neutralize the Last-Event-ID header read and event-store
+replay plumbing with a loud TODO, leaving the event store itself alone when
+it may still serve other purposes (audit logging, debugging). Confidence
+"review": every flagged site still needs a human pass.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from .base import Fixer, FixResult
+
+SPEC_URL = "https://modelcontextprotocol.io/specification/2026-07-28/changelog"
+COOKBOOK = "cookbook/08-sse-resumability-removed.md"
+TODO = (
+    "# TODO(mcp-migrate): SSE resumability via Last-Event-ID is removed; "
+    f"see {SPEC_URL} and {COOKBOOK}"
+)
+
+# The actual header read -- not every downstream use of a variable named
+# `last_event_id` on a block-opener line.
+HEADER_ACCESS_RX = re.compile(
+    r'\.headers\s*(?:\.get\(\s*|\[\s*)["\']Last-Event-ID["\']'
+    r'|os\.environ\s*(?:\.get\(\s*|\[\s*)["\']LAST_EVENT_ID["\']',
+    re.IGNORECASE,
+)
+REPLAY_CALL_RX = re.compile(r"\.replay_after\s*\(")
+
+
+def _safe_to_comment_out(line: str) -> bool:
+    """Commenting out must not leave a dangling suite or multiline expression."""
+    stripped = line.rstrip("\n").rstrip()
+    if stripped.endswith(":"):
+        return False
+    if stripped.endswith(("(", "[", "{", "\\")):
+        return False
+    return True
+
+
+def _resumability_hit(line: str) -> str | None:
+    if HEADER_ACCESS_RX.search(line):
+        return "Last-Event-ID header access"
+    if REPLAY_CALL_RX.search(line):
+        return "event-store replay call"
+    return None
+
+
+class SseResumabilityFixer(Fixer):
+    rule_id = "R014"
+    title = "Comment out Last-Event-ID resumability plumbing, leave a TODO"
+    confidence = "review"
+
+    def fix(self, source: str, path: Path) -> FixResult:
+        lines = source.splitlines(keepends=True)
+        out: list[str] = []
+        changes: list[str] = []
+
+        for i, raw_line in enumerate(lines, start=1):
+            stripped = raw_line.lstrip(" \t")
+            already_commented = stripped.startswith("#")
+            ends_as_block_opener = raw_line.rstrip("\n").rstrip().endswith(":")
+            hit = (
+                None
+                if already_commented or ends_as_block_opener
+                else _resumability_hit(raw_line)
+            )
+
+            if hit:
+                indent = raw_line[: len(raw_line) - len(stripped)]
+                newline = "\n" if raw_line.endswith("\n") else ""
+                body = stripped.rstrip("\n")
+                todo_added = False
+
+                if not (out and out[-1].strip(" \t\n") == TODO):
+                    out.append(f"{indent}{TODO}{newline}")
+                    todo_added = True
+                if _safe_to_comment_out(raw_line):
+                    out.append(f"{indent}# {body}{newline}")
+                    changes.append(f"line {i}: commented out {hit}, added TODO")
+                elif todo_added:
+                    out.append(raw_line)
+                    changes.append(f"line {i}: added TODO for {hit}")
+                else:
+                    out.append(raw_line)
+            else:
+                out.append(raw_line)
+
+        new_text = "".join(out)
+        if not changes:
+            return self.unchanged(source)
+        return self.result(new_text, changes)

--- a/tests/test_fixers.py
+++ b/tests/test_fixers.py
@@ -39,7 +39,7 @@ def fix(name: str, source: str, path: str = "server.py"):
 # ---------------------------------------------------------------------------
 
 def test_ships_a_fixer_for_every_rule_the_task_calls_out():
-    assert {"R001", "R004", "R005", "R006", "R017"} <= FIXER_RULE_IDS
+    assert {"R001", "R004", "R005", "R006", "R014", "R017"} <= FIXER_RULE_IDS
 
 
 def test_every_fixer_has_a_valid_confidence_and_metadata():
@@ -268,6 +268,86 @@ def test_r006_idempotent():
     )
     once = fix("SseTransportFixer", before)
     twice = fix("SseTransportFixer", once.text)
+    assert twice.changed is False
+    assert twice.text == once.text
+
+
+# ---------------------------------------------------------------------------
+# R014 -- SSE resumability (Last-Event-ID)
+# ---------------------------------------------------------------------------
+
+R014_BEFORE = (
+    'def handle_reconnect(request):\n'
+    '    last_event_id = request.headers.get("Last-Event-ID")\n'
+    '    if last_event_id is None:\n'
+    '        return []\n'
+    '    return list(_EventLog().replay_after(last_event_id))\n'
+)
+R014_AFTER = (
+    'def handle_reconnect(request):\n'
+    '    # TODO(mcp-migrate): SSE resumability via Last-Event-ID is removed; see '
+    'https://modelcontextprotocol.io/specification/2026-07-28/changelog and '
+    'cookbook/08-sse-resumability-removed.md\n'
+    '    # last_event_id = request.headers.get("Last-Event-ID")\n'
+    '    if last_event_id is None:\n'
+    '        return []\n'
+    '    # TODO(mcp-migrate): SSE resumability via Last-Event-ID is removed; see '
+    'https://modelcontextprotocol.io/specification/2026-07-28/changelog and '
+    'cookbook/08-sse-resumability-removed.md\n'
+    '    # return list(_EventLog().replay_after(last_event_id))\n'
+)
+
+
+def test_r014_comments_out_header_read_and_replay_call():
+    result = fix("SseResumabilityFixer", R014_BEFORE)
+    assert result.changed
+    assert result.text == R014_AFTER
+    assert FIXERS["SseResumabilityFixer"].confidence == "review"
+    ast.parse(result.text)
+
+
+def test_r014_skips_block_opener_header_reads():
+    before = 'if request.headers.get("Last-Event-ID"):\n    replay()\n'
+    result = fix("SseResumabilityFixer", before)
+    assert result.changed is False
+    assert result.text == before
+
+
+def test_r014_adds_todo_without_touching_replay_after_def():
+    before = (
+        "class _EventLog:\n"
+        "    def replay_after(self, last_event_id: str):\n"
+        "        if event_id == last_event_id:\n"
+        "            yield event_id, payload\n"
+    )
+    result = fix("SseResumabilityFixer", before)
+    assert result.changed is False
+    assert result.text == before
+    ast.parse(result.text)
+
+
+def test_r014_comments_out_bracket_header_access():
+    before = 'last_id = request.headers["Last-Event-ID"]\n'
+    result = fix("SseResumabilityFixer", before)
+    assert result.changed
+    assert '# last_id = request.headers["Last-Event-ID"]' in result.text
+    ast.parse(result.text)
+
+
+def test_r014_leaves_event_store_append_logic_alone():
+    before = (
+        "class _EventLog:\n"
+        "    def append(self, event_id: str, payload: dict) -> None:\n"
+        "        self._events.append((event_id, payload))\n"
+    )
+    result = fix("SseResumabilityFixer", before)
+    assert result.changed is False
+    assert result.text == before
+
+
+def test_r014_idempotent():
+    once = fix("SseResumabilityFixer", R014_BEFORE)
+    twice = fix("SseResumabilityFixer", once.text)
     assert twice.changed is False
     assert twice.text == once.text
 


### PR DESCRIPTION
## Summary

Add a `review`-confidence fixer for R014 that comments out `Last-Event-ID` header reads and `.replay_after()` call sites, leaving a `# TODO(mcp-migrate): ...` pointing at `cookbook/08-sse-resumability-removed.md`.

## Motivation

Issue #15 requests a fixer for SSE stream resumability removal (SEP-2575). Servers that still read `Last-Event-ID` or replay from an event store need a loud, mechanical starting point — same TODO-annotation pattern as R001/R007.

## Changes

- New `SseResumabilityFixer` in `src/mcp_migrate/fixers/r014_sse_resumability.py`
- Comments out `.headers.get/["Last-Event-ID"]` and `os.environ["LAST_EVENT_ID"]` reads
- Comments out `.replay_after(...)` call sites
- Skips block-opener lines (matching R001) and event-store `append` logic
- Tests: golden before/after, idempotency, bracket header access, block-opener skip, event-store preservation

## Tests

```bash
pytest tests/test_fixers.py -k r014 -v   # 6 passed
pytest tests/ -q                          # 227 passed
```

## Notes

- `def replay_after(...)` definitions are left untouched (block opener); only call sites and header reads are neutralized.
- Event-store infrastructure used for non-resumability purposes (audit logging) is intentionally out of scope.

Fixes #15