### PR TITLE
feat(rules): port R009 (initialize handshake) to TypeScript

### DIFF
--- a/src/mcp_migrate/rules/r009_initialize_handshake_removed.py
+++ b/src/mcp_migrate/rules/r009_initialize_handshake_removed.py
@@ -12,6 +12,32 @@ HANDSHAKE_CODE_RX = re.compile(
     r"\bInitializeRequest\b|\bInitializeResult\b|\bInitializedNotification\b"
 )
 
+# --- TypeScript -----------------------------------------------------------
+#
+# The same three SDK names, with one difference that matters: the TS SDK
+# exports a Zod schema alongside the inferred type, and the schema is the
+# name a server actually writes --
+# `server.setRequestHandler(InitializeRequestSchema, ...)`.
+# `\bInitializeRequest\b` cannot match inside `InitializeRequestSchema`
+# (there is no word boundary before `Schema`), so a trailing-suffix match
+# is required or this port would find nothing on the one shape it most
+# needs to catch. Same treatment `r011_ping_removed.py` gives
+# `PingRequest\w*`, for the same reason.
+TS_HANDSHAKE_CODE_RX = (
+    r"\bInitializeRequest\w*|\bInitializeResult\w*|\bInitializedNotification\w*"
+)
+
+# The wire name is spelled the same in both languages, and needs
+# `search_wire` in both for the same reason -- see the note in
+# `_check_python`.
+WIRE_RX = r"notifications/initialized"
+
+MESSAGE_CODE = (
+    "References the removed initialize handshake (InitializeRequest/"
+    "InitializeResult/InitializedNotification)."
+)
+MESSAGE_WIRE = "References the removed notifications/initialized handshake message."
+
 
 class InitializeHandshakeStillImplemented(Rule):
     id = "R009"
@@ -24,25 +50,48 @@ class InitializeHandshakeStillImplemented(Rule):
         "handling and advertise protocol versions, capabilities and identity through "
         "server/discover instead."
     )
+    languages = ("python", "typescript")
 
     def check(self, project: Project) -> list[Finding]:
+        if project.language == "typescript":
+            return self._check_ts(project)
+        return self._check_python(project)
+
+    def _check_python(self, project: Project) -> list[Finding]:
         out: list[Finding] = []
         # search_code: a comment or docstring mentioning InitializeRequest
         # isn't a real handler for it.
         for f, line, text in project.search_code(HANDSHAKE_CODE_RX.pattern):
-            out.append(self.finding(
-                "References the removed initialize handshake (InitializeRequest/"
-                "InitializeResult/InitializedNotification).",
-                f, line, text,
-            ))
+            out.append(self.finding(MESSAGE_CODE, f, line, text))
         # `notifications/initialized` is only ever valid as a JSON-RPC
         # method-name string -- it can't appear as a bare code identifier --
         # so it always starts inside a STRING token and search_code would
         # silently never find it. Match the literal directly instead, the
         # same way r004_tool_ordering.py matches the literal `tools/list`.
-        for f, line, text in project.search_wire(r"notifications/initialized"):
-            out.append(self.finding(
-                "References the removed notifications/initialized handshake message.",
-                f, line, text,
-            ))
+        for f, line, text in project.search_wire(WIRE_RX):
+            out.append(self.finding(MESSAGE_WIRE, f, line, text))
         return out
+
+    def _check_ts(self, project: Project) -> list[Finding]:
+        # Same two signals and the same two search modes, for the same
+        # reasons: the SDK schema names are code, so a JSDoc block
+        # explaining that the handshake was removed must not read as an
+        # implementation of it; the wire name only ever exists inside a
+        # string literal, which `search_code` discards wholesale.
+        seen: set[tuple[str, int]] = set()
+        out: list[Finding] = []
+        for pattern, message, search in (
+            (TS_HANDSHAKE_CODE_RX, MESSAGE_CODE, project.search_code),
+            (WIRE_RX, MESSAGE_WIRE, project.search_wire),
+        ):
+            for f, line, text in search(pattern):
+                # One dispatcher line can carry both signals --
+                # `case "notifications/initialized": return this.onInitializedNotification()`
+                # is a single handshake implementation, not two. Each
+                # finding is a separate grade penalty, so charging one line
+                # twice for one problem overstates it.
+                if (str(f.path), line) in seen:
+                    continue
+                seen.add((str(f.path), line))
+                out.append(self.finding(message, f, line, text))
+        return sorted(out, key=lambda x: (str(x.path or ""), x.line or 0))

--- a/tests/test_typescript.py
+++ b/tests/test_typescript.py
@@ -25,6 +25,9 @@ from mcp_migrate.rules.r003_routing_headers import MissingRoutingHeaders
 from mcp_migrate.rules.r004_tool_ordering import NondeterministicToolOrder
 from mcp_migrate.rules.r005_extensions import NoExtensionsDeclared
 from mcp_migrate.rules.r006_sse_transport_deprecated import DeprecatedSSETransport
+from mcp_migrate.rules.r009_initialize_handshake_removed import (
+    InitializeHandshakeStillImplemented,
+)
 from mcp_migrate.rules.r011_ping_removed import PingRemoved
 from mcp_migrate.rules.r015_result_type_required import RequiredResultTypeMissing
 from mcp_migrate.rules.r016_cacheable_result_required import (
@@ -500,6 +503,104 @@ export function handle(message: string) {
 """
     project = load_project(_write(tmp_path, "game.ts", code)).for_language("typescript")
     assert PingRemoved().check(project) == []
+# --- R009: the removed initialize handshake ------------------------------
+
+def test_r009_finds_the_initialize_handshake_in_typescript(tmp_path):
+    code = """\
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import {
+  InitializeRequestSchema,
+  InitializedNotificationSchema,
+} from "@modelcontextprotocol/sdk/types.js";
+
+const server = new Server({ name: "demo", version: "1.0.0" });
+
+server.setRequestHandler(InitializeRequestSchema, async () => {
+  return { protocolVersion: "2025-06-18", capabilities: {}, serverInfo: {} };
+});
+
+server.setNotificationHandler(InitializedNotificationSchema, async () => {
+  ready = true;
+});
+"""
+    project = load_project(_write(tmp_path, "server.ts", code)).for_language("typescript")
+    findings = InitializeHandshakeStillImplemented().check(project)
+    # The two imports and the two registrations -- four lines, four findings.
+    assert [f.line for f in findings] == [3, 4, 9, 13]
+    assert all("initialize handshake" in f.message for f in findings)
+
+
+def test_r009_finds_the_wire_name_in_typescript(tmp_path):
+    # The literal only ever exists inside a string, so this is the half
+    # search_code would silently never find.
+    code = """\
+export async function handshake(send: (m: unknown) => void) {
+  send({ jsonrpc: "2.0", method: "notifications/initialized" });
+}
+"""
+    project = load_project(_write(tmp_path, "client.ts", code)).for_language("typescript")
+    findings = InitializeHandshakeStillImplemented().check(project)
+    assert len(findings) == 1
+    assert findings[0].line == 2
+    assert "notifications/initialized" in findings[0].message
+
+
+def test_r009_charges_a_dual_signal_line_once(tmp_path):
+    # Both signals land on line 2. That is one handshake implementation,
+    # and one finding -- findings are grade penalties.
+    code = """\
+switch (method) {
+  case "notifications/initialized": return onInitializedNotification();
+}
+"""
+    project = load_project(_write(tmp_path, "dispatch.ts", code)).for_language("typescript")
+    findings = InitializeHandshakeStillImplemented().check(project)
+    assert len(findings) == 1
+    assert findings[0].line == 2
+
+
+def test_r009_stays_silent_on_migrated_typescript_server(tmp_path):
+    code = """\
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+
+const server = new Server({ name: "demo", version: "1.0.0" });
+
+server.setRequestHandler("server/discover", async () => {
+  return { protocolVersions: ["2026-07-28"], capabilities: {} };
+});
+"""
+    project = load_project(_write(tmp_path, "server.ts", code)).for_language("typescript")
+    assert InitializeHandshakeStillImplemented().check(project) == []
+
+
+def test_r009_ignores_the_handshake_named_only_in_a_comment(tmp_path):
+    code = """\
+// Migration note: we deleted the InitializeRequestSchema handler and the
+// notifications/initialized round trip in the 2026-07-28 migration.
+/** InitializeResult and InitializedNotification are gone; see server/discover. */
+export const NOTE = 1;
+"""
+    project = load_project(_write(tmp_path, "docs.ts", code)).for_language("typescript")
+    assert InitializeHandshakeStillImplemented().check(project) == []
+
+
+def test_r009_does_not_fire_on_an_unrelated_initialize(tmp_path):
+    # `initialize` is one of the most overloaded words in software. Only
+    # the SDK's own compound names count.
+    code = """\
+export class Pool {
+  async initialize() {
+    this.ready = true;
+  }
+}
+
+const db = new Pool();
+await db.initialize();
+"""
+    project = load_project(_write(tmp_path, "pool.ts", code)).for_language("typescript")
+    assert InitializeHandshakeStillImplemented().check(project) == []
+
+
 # --- R016: ttlMs/cacheScope on list/read results -------------------------
 
 def test_r016_finds_missing_cache_metadata_in_typescript(tmp_path):


### PR DESCRIPTION
Fixes #38.

Ports **R009** (`Still implements the initialize / notifications/initialized handshake`, `breaking`) to TypeScript. `languages = ("python", "typescript")`, `check()` splits on `project.language`, and the Python path moves into `_check_python` unchanged — same layout as the R001/R006/R011 ports.

## The two signals

| Signal | Search mode | Why |
| --- | --- | --- |
| `InitializeRequest\w*` / `InitializeResult\w*` / `InitializedNotification\w*` | `search_code` | SDK names are code. A JSDoc block explaining that the handshake was removed is not a handler for it. |
| `notifications/initialized` | `search_wire` | Only ever valid as a JSON-RPC method-name string, so it always starts inside a string token and `search_code` would never find it. |

**The `\w*` suffix is the load-bearing difference from Python.** TypeScript ships a Zod schema alongside the inferred type, and the schema is the name a server actually writes:

```ts
server.setRequestHandler(InitializeRequestSchema, async () => { ... });
```

`\bInitializeRequest\b` cannot match inside `InitializeRequestSchema` — there is no word boundary before `Schema` — so without the suffix this port would find nothing on the one shape it most needs to catch. `r011_ping_removed.py` already does exactly this with `PingRequest\w*`.

## One line, one finding

A dispatcher can carry both signals on the same line:

```ts
case "notifications/initialized": return this.onInitializedNotification();
```

That is a single handshake implementation, so it is reported once. Findings are grade penalties, and double-charging one line for one problem overstates it — same dedupe R001 does for `const mcpSessionId = req.headers["mcp-session-id"]`.

## False positives

`initialize` on its own is one of the most overloaded words in software, so nothing here matches it — only the SDK's compound names. There is a test asserting a plain `db.initialize()` stays silent.

## Tests

Six new tests in `tests/test_typescript.py`: the SDK-name half, the wire half, the dual-signal line, a migrated server (`server/discover`), a file naming the handshake only in comments and JSDoc, and the unrelated `initialize()` case.

Full suite: **229 passed** (223 on `main` + 6). Verified end to end — `mcp-migrate check` on a TypeScript server now reports R009, and the coverage line moves to `10 of 21`.

---

*Supersedes #78, which was opened from the wrong account.*