### PR TITLE
feat(rules): port R010 (server/discover missing) to TypeScript

### DIFF
--- a/src/mcp_migrate/rules/r010_server_discover_missing.py
+++ b/src/mcp_migrate/rules/r010_server_discover_missing.py
@@ -57,6 +57,51 @@ DISCOVER_CODE_RX = re.compile(
 )
 
 
+# --- TypeScript -----------------------------------------------------------
+#
+# The same evidence/absence shape, with TypeScript's registration idioms.
+#
+# Handler registration in the TS SDK comes in two layers, and both have to
+# count or the gate silently never opens:
+#
+#   * low-level `Server` -- `server.setRequestHandler(ListToolsRequestSchema, ...)`,
+#     and `setNotificationHandler` alongside it. The schema argument may
+#     also be a bare wire string (`setRequestHandler("tools/list", ...)`),
+#     which r016 already had to accommodate.
+#   * `McpServer` -- `server.tool(...)`, `server.registerTool(...)`,
+#     `.resource(`/`.registerResource(`, `.prompt(`/`.registerPrompt(`.
+#
+# The `McpServer` names are the generic-looking half: a `.tool(` on some
+# unrelated builder object is not an MCP registration. Python guards the
+# same risk by requiring FastMCP evidence in the project before counting
+# `.tool(`; the TypeScript equivalent is requiring the SDK itself to be
+# imported somewhere, which is both stricter and easier to be sure of.
+TS_LOWLEVEL_HANDLER_RX = (
+    r"\.set(?:Request|Notification)Handler\s*\("
+)
+TS_MCPSERVER_REGISTER_RX = (
+    r"\.(?:registerTool|registerResource|registerPrompt|tool|resource|prompt)\s*\("
+)
+# `@modelcontextprotocol/sdk` in an import or require. Without it, a
+# `.tool(` is somebody else's builder API.
+TS_SDK_IMPORT_RX = r"@modelcontextprotocol/sdk"
+
+# Evidence the project implements server/discover.
+#
+# The wire name is a string literal, so it needs search_wire -- the same
+# reason r009's `notifications/initialized` does. The code half has to be
+# anchored to a *whole* name, not a substring: the Python side learned this
+# the hard way when `_try_discover_fields_from_existing_epic` read as
+# "implements server/discover" and suppressed the rule for a whole project.
+# `discoverCapabilities()` or `autoDiscoverTools()` must not count either,
+# so the identifier alternatives match `discover` exactly, allowing only
+# the conventional handler prefixes.
+TS_DISCOVER_CODE_RX = (
+    r"\b(?:handle|on|server)?[Dd]iscover\s*(?:\(|=|:)"
+    r"|\bfunction\s+(?:handle|on|server)?[Dd]iscover\b"
+)
+
+
 def _has_request_handlers(project: Project) -> bool:
     if any(project.search_code(LOWLEVEL_HANDLER_RX.pattern)):
         return True
@@ -72,6 +117,35 @@ def _has_discover(project: Project) -> bool:
     if any(project.search_code(DISCOVER_CODE_RX.pattern)):
         return True
     if any(project.search(r"server/discover")):
+        return True
+    return False
+
+
+def _ts_has_request_handlers(project: Project) -> bool:
+    if any(project.search_code(TS_LOWLEVEL_HANDLER_RX)):
+        return True
+    # The McpServer names only count with the SDK actually imported. The
+    # import lives in a string (`from "@modelcontextprotocol/sdk/..."`), so
+    # this is search_wire: search_code discards string tokens and would
+    # never see it, and plain search would count a README-style comment
+    # naming the package as proof the package is in use.
+    if any(project.search_wire(TS_SDK_IMPORT_RX)) and any(
+        project.search_code(TS_MCPSERVER_REGISTER_RX)
+    ):
+        return True
+    return False
+
+
+def _ts_has_discover(project: Project) -> bool:
+    if any(project.search_code(TS_DISCOVER_CODE_RX)):
+        return True
+    # search_wire rather than the Python side's raw search: the wire name
+    # is a string literal, but a JSDoc block saying "server/discover is not
+    # implemented yet" is prose, and letting prose satisfy the check would
+    # suppress the finding for the whole project -- the worst failure mode
+    # available here, since nobody ever sees a finding that was silently
+    # withheld.
+    if any(project.search_wire(r"server/discover")):
         return True
     return False
 
@@ -101,16 +175,26 @@ class ServerDiscoverMissing(Rule):
         "versions, capabilities and server identity before doing anything else. Add a "
         "handler for it alongside your other request handlers."
     )
+    languages = ("python", "typescript")
 
     def check(self, project: Project) -> list[Finding]:
+        if project.language == "typescript":
+            has_handlers, has_discover = (
+                _ts_has_request_handlers(project), _ts_has_discover(project),
+            )
+        else:
+            has_handlers, has_discover = (
+                _has_request_handlers(project), _has_discover(project),
+            )
+
         # Gate hard on the project actually registering *some* MCP request
         # handler first -- a project with no handlers at all isn't an MCP
         # server (or is a client, or a library), and flagging it for
         # missing server/discover would just be noise unrelated to this
         # check's purpose.
-        if not _has_request_handlers(project):
+        if not has_handlers:
             return []
-        if _has_discover(project):
+        if has_discover:
             return []
         return [self.finding(
             "This project registers MCP request handlers (tools/resources/prompts) "

--- a/tests/test_typescript.py
+++ b/tests/test_typescript.py
@@ -32,6 +32,7 @@ from mcp_migrate.rules.r009_initialize_handshake_removed import (
 from mcp_migrate.rules.r019_tasks_polling_replaces_blocking_result import (
     TasksPollingReplacesBlockingResult,
 )
+from mcp_migrate.rules.r010_server_discover_missing import ServerDiscoverMissing
 from mcp_migrate.rules.r011_ping_removed import PingRemoved
 from mcp_migrate.rules.r012_logging_set_level_removed import LoggingSetLevelRemoved
 from mcp_migrate.rules.r015_result_type_required import RequiredResultTypeMissing
@@ -923,6 +924,125 @@ server.setRequestHandler("tools/list", async () => {
     findings = CacheableResultMetadataMissing().check(project)
     assert len(findings) == 1
     assert findings[0].line == 5
+
+
+# --- R010: server/discover missing ---------------------------------------
+
+def test_r010_finds_handlers_without_discover_in_typescript(tmp_path):
+    code = """\
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js";
+
+const server = new Server({ name: "demo", version: "1.0.0" });
+
+server.setRequestHandler(ListToolsRequestSchema, async () => ({ tools: [] }));
+"""
+    project = load_project(_write(tmp_path, "server.ts", code)).for_language("typescript")
+    findings = ServerDiscoverMissing().check(project)
+    assert len(findings) == 1
+    assert "server/discover" in findings[0].message
+
+
+def test_r010_counts_mcpserver_registration_when_the_sdk_is_imported(tmp_path):
+    code = """\
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+
+const server = new McpServer({ name: "demo", version: "1.0.0" });
+
+server.registerTool("echo", { description: "echo" }, async () => ({ content: [] }));
+"""
+    project = load_project(_write(tmp_path, "server.ts", code)).for_language("typescript")
+    assert len(ServerDiscoverMissing().check(project)) == 1
+
+
+def test_r010_stays_silent_when_discover_is_implemented_in_typescript(tmp_path):
+    code = """\
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js";
+
+const server = new Server({ name: "demo", version: "1.0.0" });
+
+server.setRequestHandler(ListToolsRequestSchema, async () => ({ tools: [] }));
+server.setRequestHandler("server/discover", async () => ({
+  protocolVersions: ["2026-07-28"],
+  capabilities: {},
+}));
+"""
+    project = load_project(_write(tmp_path, "server.ts", code)).for_language("typescript")
+    assert ServerDiscoverMissing().check(project) == []
+
+
+def test_r010_accepts_a_named_discover_handler_in_typescript(tmp_path):
+    code = """\
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js";
+
+const server = new Server({ name: "demo", version: "1.0.0" });
+server.setRequestHandler(ListToolsRequestSchema, async () => ({ tools: [] }));
+
+export async function handleDiscover() {
+  return { protocolVersions: ["2026-07-28"], capabilities: {} };
+}
+"""
+    project = load_project(_write(tmp_path, "server.ts", code)).for_language("typescript")
+    assert ServerDiscoverMissing().check(project) == []
+
+
+def test_r010_is_not_satisfied_by_a_name_merely_containing_discover(tmp_path):
+    # The Python side's worst bug: `_try_discover_fields_from_existing_epic`
+    # read as "implements server/discover" and suppressed the rule for a
+    # whole project. A withheld finding is the one nobody ever sees.
+    code = """\
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js";
+
+const server = new Server({ name: "demo", version: "1.0.0" });
+server.setRequestHandler(ListToolsRequestSchema, async () => ({ tools: [] }));
+
+async function autoDiscoverTools() { return []; }
+async function discoverCapabilitiesFromCache() { return {}; }
+"""
+    project = load_project(_write(tmp_path, "server.ts", code)).for_language("typescript")
+    assert len(ServerDiscoverMissing().check(project)) == 1
+
+
+def test_r010_is_not_satisfied_by_discover_named_only_in_a_comment(tmp_path):
+    code = """\
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js";
+
+const server = new Server({ name: "demo", version: "1.0.0" });
+server.setRequestHandler(ListToolsRequestSchema, async () => ({ tools: [] }));
+
+// TODO: implement server/discover before the 2026-07-28 deadline.
+"""
+    project = load_project(_write(tmp_path, "server.ts", code)).for_language("typescript")
+    assert len(ServerDiscoverMissing().check(project)) == 1
+
+
+def test_r010_stays_silent_on_typescript_with_no_handlers(tmp_path):
+    # A client, or a library. Not an MCP server, so the absence of
+    # server/discover says nothing about it.
+    code = """\
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+
+const client = new Client({ name: "demo", version: "1.0.0" });
+await client.connect(transport);
+"""
+    project = load_project(_write(tmp_path, "client.ts", code)).for_language("typescript")
+    assert ServerDiscoverMissing().check(project) == []
+
+
+def test_r010_stays_silent_without_the_sdk_in_play(tmp_path):
+    # `.tool(` and `.prompt(` are generic builder-API names. Without the
+    # SDK imported anywhere, this is somebody else's fluent interface.
+    code = """\
+const pipeline = builder
+  .tool("resize", { width: 100 })
+  .prompt("describe this image");
+"""
+    project = load_project(_write(tmp_path, "build.ts", code)).for_language("typescript")
+    assert ServerDiscoverMissing().check(project) == []
 
 
 # --- the language split itself --------------------------------------------


### PR DESCRIPTION
Fixes #39.

Ports **R010** (`Registers MCP request handlers but never implements server/discover`, `advisory`) to TypeScript. `languages = ("python", "typescript")`, `check()` splits on `project.language`, Python path unchanged.

This one is an evidence/absence rule rather than a pattern list, so the port is two gates — and each has a distinct way to fail badly.

## Gate 1: does this project register handlers?

Two layers, and **both** have to count or the gate never opens and the rule silently checks nothing:

| Shape | Pattern | Gated? |
| --- | --- | --- |
| low-level `Server` | `.setRequestHandler(` / `.setNotificationHandler(` | no — unambiguous |
| `McpServer` | `.registerTool(`, `.tool(`, `.resource(`, `.prompt(`, … | **yes** |

The `McpServer` names are generic builder-API vocabulary — a `.tool(` on somebody else's fluent interface is not an MCP registration. Python guards the identical risk by requiring FastMCP evidence in the project before counting `.tool(`; the TypeScript equivalent is requiring `@modelcontextprotocol/sdk` to be imported somewhere, which is both stricter and easier to be certain of.

That import check is `search_wire`, deliberately: the package name lives inside a string literal, so `search_code` drops it and would never see it, while raw `search` would accept a comment *naming* the package as proof the package is in use.

## Gate 2: is `server/discover` implemented?

This is where the Python side has its worst recorded bug, documented in its own comments: `\bdef\s+\w*discover\w*\b` matched mcp-atlassian's `_try_discover_fields_from_existing_epic` and **suppressed the rule for that entire project**. A withheld finding is the one nobody ever sees — strictly worse than a false one somebody can argue with.

So the TypeScript identifier match is anchored to the whole name, allowing only the conventional handler prefixes (`discover`, `handleDiscover`, `onDiscover`, `serverDiscover`). These do **not** satisfy it, and there's a test pinning each:

```ts
async function autoDiscoverTools() { ... }
async function discoverCapabilitiesFromCache() { ... }
```

The wire half uses `search_wire` rather than the Python side's raw `search`, for the same reason — a JSDoc line reading `// TODO: implement server/discover` is prose, and letting prose satisfy an absence check suppresses the finding for the whole project.

## Tests

Eight, in `tests/test_typescript.py`:

- fires on low-level `setRequestHandler` with no discover
- fires on `McpServer.registerTool` with the SDK imported
- silent when `server/discover` is handled by wire name
- silent for a named `handleDiscover` function
- **still fires** for substring-only names (`autoDiscoverTools`)
- **still fires** when `server/discover` appears only in a comment
- silent for a client with no handlers (not an MCP server)
- silent for a builder API with no SDK import

Full suite: **269 passed**. Verified end to end — `mcp-migrate check` reports R010 on a TypeScript server that registers handlers without `server/discover`.