### PR TITLE
fix(scan): skip *.examples.ts documentation modules by default

### DIFF
--- a/src/mcp_migrate/scan.py
+++ b/src/mcp_migrate/scan.py
@@ -35,10 +35,14 @@ TEST_DIR_SEGMENTS = {
 # The `*.test.*` / `*.spec.*` pair is close to universal in JS/TS and is
 # the dominant convention for tests that sit *beside* the module they
 # cover, where no directory segment can give them away.
+# Name is historical (tests first). Also covers type-checked docs
+# examples (*.examples.ts) used by e.g. modelcontextprotocol/typescript-sdk
+# for JSDoc snippet sync — prose that compiles, not production servers.
 TEST_FILE_PATTERNS = (
     "test_*.py", "*_test.py", "conftest.py",
     "*.test.ts", "*.test.tsx", "*.test.mts", "*.test.cts",
     "*.spec.ts", "*.spec.tsx", "*.spec.mts", "*.spec.cts",
+    "*.examples.ts", "*.examples.tsx", "*.examples.mts", "*.examples.cts",
 )
 
 

--- a/tests/test_typescript.py
+++ b/tests/test_typescript.py
@@ -1130,6 +1130,8 @@ def test_ts_scanner_handles_escapes_and_unterminated_strings():
     "src/server.test.ts",
     "src/server.spec.ts",
     "src/server.test.tsx",
+    "src/server.examples.ts",
+    "src/server.examples.tsx",
 ])
 def test_typescript_test_code_is_skipped_by_default(tmp_path, rel):
     path = tmp_path / rel
@@ -1143,6 +1145,15 @@ def test_typescript_test_code_is_scanned_with_include_tests(tmp_path):
     path.parent.mkdir(parents=True)
     path.write_text(LEGACY_TS)
     assert load_project(tmp_path, include_tests=True).files != []
+
+def test_typescript_examples_are_scanned_with_include_tests(tmp_path):
+    path = tmp_path / "src" / "mcp.examples.ts"
+    path.parent.mkdir(parents=True)
+    path.write_text(LEGACY_TS)
+    assert load_project(tmp_path).files == []
+    assert load_project(tmp_path, include_tests=True).files != []
+
+
 
 
 def test_production_typescript_that_merely_contains_test_in_the_name_is_kept(tmp_path):


### PR DESCRIPTION
﻿## Summary
- Skip `*.examples.ts` / `.tsx` / `.mts` / `.cts` by default (closes #83)
- Same skip path as other non-production patterns; `--include-tests` still scans them
- Kept name `TEST_FILE_PATTERNS` with a comment — one skip list, one `--include-tests` toggle (avoided a second parallel constant)

## Test plan
- [x] `pytest tests/test_typescript.py -k examples -q`
