### PR TITLE
feat(rules): port R008 (OpenTelemetry trace context) to TypeScript

### DIFF
--- a/src/mcp_migrate/rules/r008_trace_context.py
+++ b/src/mcp_migrate/rules/r008_trace_context.py
@@ -1,5 +1,47 @@
 from .base import Finding, Project, Rule
 
+# --- TypeScript -----------------------------------------------------------
+#
+# The Python gate is `project.imports()`, which walks the AST -- and the
+# AST is Python-only (`SourceFile.tree` stays None for every other
+# language), so the TypeScript side needs a textual equivalent.
+#
+# A quoted `@opentelemetry/...` specifier is that equivalent. The scope is
+# narrow on purpose: the string only appears in an `import`/`require`, so
+# matching it needs no anchor to the import keyword, and it cannot be
+# confused with ordinary prose about tracing. `search_wire` keeps string
+# literals (where the specifier lives) while dropping comments, so a
+# `// TODO: add @opentelemetry/api` does not read as "OpenTelemetry is in
+# use" -- which matters more here than in most rules, because this gate
+# opening is what lets the rule fire at all.
+TS_OTEL_SPECIFIER_RX = r"[\"'`]@opentelemetry/[^\"'`]*[\"'`]"
+
+# Evidence the header is actually read. Both spellings are real and both
+# have to count:
+#
+#   const tp = request.params._meta?.["traceparent"];   // string key
+#   const tp = meta.traceparent;                        // property access
+#
+# `search_wire` is the mode that sees both -- `search_code` discards string
+# tokens and would miss the first, while comments stay excluded either way,
+# so "we should read traceparent" still does not count as reading it.
+TS_TRACEPARENT_RX = r"\btraceparent\b"
+
+# The other correct way to do this, and the reason the TypeScript port is
+# quieter than the Python one: the idiomatic OTel API consumes the header
+# through the propagator rather than by name.
+#
+#   propagation.extract(context.active(), request.params._meta ?? {})
+#
+# A server written that way propagates trace context correctly and may
+# never spell `traceparent` anywhere. Flagging it would be a false positive
+# on code that already does the right thing, so the extract call counts as
+# evidence. `search_code` here: this one is a real call expression, not a
+# string.
+TS_PROPAGATION_EXTRACT_RX = r"\bpropagation\s*\.\s*extract\s*\("
+
+MESSAGE = "OpenTelemetry is in use but `traceparent` is never read from `_meta`."
+
 
 class NoTraceContextPropagation(Rule):
     id = "R008"
@@ -10,8 +52,14 @@ class NoTraceContextPropagation(Rule):
         "Read `traceparent`, `tracestate` and `baggage` off `_meta` and hand them to your "
         "tracer. Without it, agent traces break at your server."
     )
+    languages = ("python", "typescript")
 
     def check(self, project: Project) -> list[Finding]:
+        if project.language == "typescript":
+            return self._check_ts(project)
+        return self._check_python(project)
+
+    def _check_python(self, project: Project) -> list[Finding]:
         uses_otel = any("opentelemetry" in i for i in project.imports())
         if not uses_otel:
             return []
@@ -19,6 +67,17 @@ class NoTraceContextPropagation(Rule):
         # actually reading it.
         if any(project.search_code(r"traceparent")):
             return []
-        return [self.finding(
-            "OpenTelemetry is in use but `traceparent` is never read from `_meta`."
-        )]
+        return [self.finding(MESSAGE)]
+
+    def _check_ts(self, project: Project) -> list[Finding]:
+        # Same shape as Python: gate on OpenTelemetry actually being in
+        # play, then look for evidence the header is consumed. A project
+        # that does no tracing at all is not failing to propagate trace
+        # context -- it has nothing to propagate.
+        if not any(project.search_wire(TS_OTEL_SPECIFIER_RX)):
+            return []
+        if any(project.search_wire(TS_TRACEPARENT_RX)):
+            return []
+        if any(project.search_code(TS_PROPAGATION_EXTRACT_RX)):
+            return []
+        return [self.finding(MESSAGE)]

--- a/tests/test_typescript.py
+++ b/tests/test_typescript.py
@@ -26,6 +26,7 @@ from mcp_migrate.rules.r004_tool_ordering import NondeterministicToolOrder
 from mcp_migrate.rules.r005_extensions import NoExtensionsDeclared
 from mcp_migrate.rules.r006_sse_transport_deprecated import DeprecatedSSETransport
 from mcp_migrate.rules.r007_deprecated_features import DeprecatedCoreFeatures
+from mcp_migrate.rules.r008_trace_context import NoTraceContextPropagation
 from mcp_migrate.rules.r009_initialize_handshake_removed import (
     InitializeHandshakeStillImplemented,
 )
@@ -1043,6 +1044,104 @@ const pipeline = builder
 """
     project = load_project(_write(tmp_path, "build.ts", code)).for_language("typescript")
     assert ServerDiscoverMissing().check(project) == []
+
+# --- R008: OpenTelemetry trace context from _meta ------------------------
+
+def test_r008_finds_otel_without_traceparent_in_typescript(tmp_path):
+    code = """\
+import { trace } from "@opentelemetry/api";
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+
+const tracer = trace.getTracer("demo");
+
+server.setRequestHandler(CallToolRequestSchema, async (request) => {
+  return tracer.startActiveSpan("call_tool", async (span) => {
+    span.end();
+    return { content: [] };
+  });
+});
+"""
+    project = load_project(_write(tmp_path, "server.ts", code)).for_language("typescript")
+    findings = NoTraceContextPropagation().check(project)
+    assert len(findings) == 1
+    assert "traceparent" in findings[0].message
+
+
+def test_r008_stays_silent_when_traceparent_is_read_as_a_string_key(tmp_path):
+    code = """\
+import { trace } from "@opentelemetry/api";
+
+server.setRequestHandler(CallToolRequestSchema, async (request) => {
+  const parent = request.params._meta?.["traceparent"];
+  return handle(request, parent);
+});
+"""
+    project = load_project(_write(tmp_path, "server.ts", code)).for_language("typescript")
+    assert NoTraceContextPropagation().check(project) == []
+
+
+def test_r008_stays_silent_when_traceparent_is_read_as_a_property(tmp_path):
+    # The other spelling. search_code would find this one but miss the
+    # string-key form above, which is why the rule uses search_wire.
+    code = """\
+import { trace } from "@opentelemetry/api";
+
+const parent = request.params._meta.traceparent;
+"""
+    project = load_project(_write(tmp_path, "server.ts", code)).for_language("typescript")
+    assert NoTraceContextPropagation().check(project) == []
+
+
+def test_r008_stays_silent_when_the_propagator_extracts_the_context(tmp_path):
+    # The idiomatic OTel API consumes the header through the propagator and
+    # may never spell `traceparent` at all. This server does the right
+    # thing; flagging it would be a false positive on correct code.
+    code = """\
+import { context, propagation, trace } from "@opentelemetry/api";
+
+server.setRequestHandler(CallToolRequestSchema, async (request) => {
+  const parent = propagation.extract(context.active(), request.params._meta ?? {});
+  return context.with(parent, () => handle(request));
+});
+"""
+    project = load_project(_write(tmp_path, "server.ts", code)).for_language("typescript")
+    assert NoTraceContextPropagation().check(project) == []
+
+
+def test_r008_stays_silent_without_opentelemetry_in_typescript(tmp_path):
+    # No tracing at all is not a failure to propagate trace context --
+    # there is nothing to propagate.
+    code = """\
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+
+const server = new Server({ name: "demo", version: "1.0.0" });
+"""
+    project = load_project(_write(tmp_path, "server.ts", code)).for_language("typescript")
+    assert NoTraceContextPropagation().check(project) == []
+
+
+def test_r008_does_not_treat_a_commented_otel_import_as_usage(tmp_path):
+    # The gate opening is what lets this rule fire at all, so a comment
+    # planning to add OpenTelemetry must not open it.
+    code = """\
+// TODO: add "@opentelemetry/api" and start tracing tool calls.
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+"""
+    project = load_project(_write(tmp_path, "server.ts", code)).for_language("typescript")
+    assert NoTraceContextPropagation().check(project) == []
+
+
+def test_r008_still_fires_when_traceparent_is_only_in_a_comment(tmp_path):
+    # The mirror of the case above: intending to read the header is not
+    # reading it.
+    code = """\
+import { trace } from "@opentelemetry/api";
+
+// TODO: pull traceparent off _meta and seed the span context with it.
+const tracer = trace.getTracer("demo");
+"""
+    project = load_project(_write(tmp_path, "server.ts", code)).for_language("typescript")
+    assert len(NoTraceContextPropagation().check(project)) == 1
 
 
 # --- the language split itself --------------------------------------------


### PR DESCRIPTION
Fixes #37.

Ports **R008** (`Does not propagate OpenTelemetry trace context from _meta`, `advisory`) to TypeScript. `languages = ("python", "typescript")`, `check()` splits on `project.language`, Python path unchanged.

Another evidence/absence rule, so it's a gate plus an evidence check — and each half needed a TypeScript answer.

## The gate: is OpenTelemetry actually in play?

Python uses `project.imports()`, which walks the AST — and the AST is Python-only (`SourceFile.tree` stays `None` for every other language), so this needed a textual equivalent.

A quoted `@opentelemetry/...` specifier is that equivalent. The string only ever appears in an `import` or `require`, so it needs no anchor to the keyword and can't be confused with prose about tracing.

`search_wire` keeps the string literal while dropping comments, so this does **not** open the gate:

```ts
// TODO: add "@opentelemetry/api" and start tracing tool calls.
```

That matters more here than in most rules — this gate opening is the only thing that lets R008 fire at all, so a comment opening it would produce a finding against a project that does no tracing whatsoever.

## The evidence: is the header read?

`traceparent` has two real spellings in TypeScript and **both** have to count:

```ts
const tp = request.params._meta?.["traceparent"];   // string key
const tp = meta.traceparent;                        // property access
```

`search_wire` is the only mode that sees both — `search_code` discards string tokens and would miss the first. Comments stay excluded either way, so *intending* to read the header is not reading it, and there's a test pinning that the rule still fires for:

```ts
// TODO: pull traceparent off _meta and seed the span context with it.
```

## One deliberate difference from the Python rule

The idiomatic OTel API consumes the header through the propagator rather than by name:

```ts
const parent = propagation.extract(context.active(), request.params._meta ?? {});
return context.with(parent, () => handle(request));
```

A server written this way propagates trace context **correctly** and may never spell `traceparent` anywhere. Flagging it would be a false positive against code that already does the right thing, so `propagation.extract(` counts as evidence.

That makes the TypeScript port strictly quieter than the Python one. Flagging it explicitly in case you'd rather they stayed identical — but it errs in the direction this project errs in, and the same gap arguably exists on the Python side (`propagate.extract` there) if it's worth a follow-up issue.

## Tests

Seven, in `tests/test_typescript.py`:

- fires on OTel imported with no `traceparent`
- silent for the string-key read
- silent for the property read
- silent for `propagation.extract`
- silent with no OpenTelemetry at all
- silent when OTel appears only in a comment (gate stays shut)
- **still fires** when `traceparent` appears only in a comment

Full suite: **268 passed**. Verified end to end — `mcp-migrate check` reports R008 on a TypeScript server that traces without reading `traceparent`.