### PR TITLE
fix(r001): use search_code for identifier patterns in TypeScript

### DIFF
--- a/src/mcp_migrate/rules/r001_session_id_removed.py
+++ b/src/mcp_migrate/rules/r001_session_id_removed.py
@@ -53,19 +53,26 @@ class SessionIdRemoved(Rule):
         ]
 
     def _check_ts(self, project: Project) -> list[Finding]:
-        # search_wire, not search_code: in TypeScript the header name lives
-        # in a string literal, which search_code discards wholesale -- it
-        # would find nothing at all. search_wire keeps string literals and
-        # drops comments, which is exactly the split needed here.
         seen: set[tuple[str, int]] = set()
         out: list[Finding] = []
-        for pattern in (TS_IDENT_RX, TS_HEADER_RX):
-            for f, line, text in project.search_wire(pattern, flags=re.IGNORECASE):
-                # The two patterns can both hit the same line
-                # (`const mcpSessionId = req.headers["mcp-session-id"]`);
-                # that is one problem, not two.
-                if (str(f.path), line) in seen:
-                    continue
-                seen.add((str(f.path), line))
-                out.append(self.finding(self.MESSAGE, f, line, text))
+
+        # Identifiers (mcpSessionId, MCP_SESSION_ID) use search_code:
+        # a log/comment/error-message string that merely mentions the
+        # identifier isn't a real reference to it.
+        for f, line, text in project.search_code(TS_IDENT_RX, flags=re.IGNORECASE):
+            seen.add((str(f.path), line))
+            out.append(self.finding(self.MESSAGE, f, line, text))
+
+        # Header-string literals ("mcp-session-id") use search_wire:
+        # the header name lives in a string literal, which search_code
+        # discards wholesale -- it would find nothing at all. search_wire
+        # keeps string literals and drops comments.
+        for f, line, text in project.search_wire(TS_HEADER_RX, flags=re.IGNORECASE):
+            # The two patterns can both hit the same line
+            # (`const mcpSessionId = req.headers["mcp-session-id"]`);
+            # that is one problem, not two.
+            if (str(f.path), line) in seen:
+                continue
+            seen.add((str(f.path), line))
+            out.append(self.finding(self.MESSAGE, f, line, text))
         return sorted(out, key=lambda x: (str(x.path or ""), x.line or 0))

--- a/tests/test_typescript.py
+++ b/tests/test_typescript.py
@@ -362,6 +362,46 @@ def test_r001_ignores_the_header_named_only_in_prose(tmp_path):
     assert SessionIdRemoved().check(project) == []
 
 
+def test_r001_ignores_the_identifier_in_a_log_string(tmp_path):
+    # R001's identifier half uses search_code, which skips string tokens.
+    # A console.info/log/warn/error string *naming* mcpSessionId is prose,
+    # not a real reference to it.
+    project = load_project(_write(
+        tmp_path, "server.ts",
+        'console.info("Ignoring obsolete mcpSessionId metadata");\n'
+        'export const x = 1;\n',
+    )).for_language("typescript")
+    assert SessionIdRemoved().check(project) == []
+
+
+def test_r001_finds_header_access_in_typescript(tmp_path):
+    # The header-string half still uses search_wire, so a real header
+    # access still fires.
+    project = load_project(_write(
+        tmp_path, "transport.ts",
+        'export function handle(req) {\n'
+        '  const sid = req.headers["mcp-session-id"];\n'
+        '  return sid;\n'
+        '}\n',
+    )).for_language("typescript")
+    findings = SessionIdRemoved().check(project)
+    assert len(findings) == 1
+    assert findings[0].line == 2
+
+
+def test_r001_finds_identifier_as_code_in_typescript(tmp_path):
+    # A real variable declaration still fires through search_code.
+    project = load_project(_write(
+        tmp_path, "server.ts",
+        'export function handle(req) {\n'
+        '  const mcpSessionId = req.sessionId;\n'
+        '  return mcpSessionId;\n'
+        '}\n',
+    )).for_language("typescript")
+    findings = SessionIdRemoved().check(project)
+    assert {f.line for f in findings} == {2, 3}
+
+
 # --- R005: extensions map on ServerCapabilities --------------------------
 
 def test_r005_finds_missing_extensions_in_typescript(tmp_path):


### PR DESCRIPTION
R001's `_check_ts` was running both the identifier pattern (`mcpSessionId`, `MCP_SESSION_ID`) and the header-literal pattern (`"mcp-session-id"`) through `search_wire`. That mode keeps string literals, so a log string like:

```ts
console.info("Ignoring obsolete mcpSessionId metadata");
```

would report as `breaking`.

## Change

Split the two halves so each uses the right search mode:

- **identifier pattern** (`mcpSessionId`, `MCP_SESSION_ID`) → `search_code` — skips string tokens, so a log/error-message string naming the identifier is not a false positive.
- **header-literal pattern** (`"mcp-session-id"`) → `search_wire` — keeps string literals (where the header name lives) and drops comments/prose.

## Tests

Three new tests cover the exact scenarios from the issue:

- `test_r001_ignores_the_identifier_in_a_log_string` — `console.info("... mcpSessionId ...")` produces nothing.
- `test_r001_finds_header_access_in_typescript` — `req.headers["mcp-session-id"]` still fires.
- `test_r001_finds_identifier_as_code_in_typescript` — `const mcpSessionId = ...` in code still fires.

All 272 existing tests continue to pass.

Closes #90.