### PR TITLE
fix(r019): add TODO-annotation fixer for removed tasks methods

### DIFF
--- a/src/mcp_migrate/fixers/r019_tasks_polling.py
+++ b/src/mcp_migrate/fixers/r019_tasks_polling.py
@@ -1,0 +1,91 @@
+"""Fixer for R019 -- removed tasks/list and blocking tasks/result.
+
+There is no mechanical replacement for a blocking wait: the 2026-07-28
+spec replaces it with a tasks/get + tasks/update polling loop, and tasks
+moved into the io.modelcontextprotocol/tasks extension. So this fixer does
+the one thing that is safe without understanding the surrounding control
+flow -- flag each flagged call site with a loud TODO and comment out the
+line when that cannot break a multiline expression. Confidence "review":
+every flagged site still needs a human pass.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from .base import Fixer, FixResult
+
+SPEC_URL = "https://modelcontextprotocol.io/specification/2026-07-28/changelog"
+COOKBOOK = "cookbook/11-tasks-polling.md"
+TODO = (
+    "# TODO(mcp-migrate): tasks/list and blocking tasks/result are removed; "
+    f"poll with tasks/get + tasks/update and declare io.modelcontextprotocol/tasks "
+    f"under extensions — see {SPEC_URL} and {COOKBOOK}"
+)
+
+TASKS_CODE_RX = re.compile(r"\bListTasksRequest\b|\bGetTaskPayloadRequest\b")
+TASKS_WIRE_RX = re.compile(r"""["']tasks/(?:list|result)["']""")
+
+
+def _safe_to_comment_out(line: str) -> bool:
+    """Commenting out must not leave a dangling suite or multiline expression."""
+    stripped = line.rstrip("\n").rstrip()
+    if stripped.endswith(":"):
+        return False
+    if stripped.endswith(("(", "[", "{", "\\")):
+        return False
+    return True
+
+
+def _tasks_hit(line: str) -> str | None:
+    if TASKS_CODE_RX.search(line):
+        return "removed tasks SDK request type"
+    if TASKS_WIRE_RX.search(line):
+        return "removed tasks/list or blocking tasks/result method"
+    return None
+
+
+class TasksPollingFixer(Fixer):
+    rule_id = "R019"
+    title = "Comment out removed tasks/list or blocking tasks/result usage, leave a TODO"
+    confidence = "review"
+
+    def fix(self, source: str, path: Path) -> FixResult:
+        lines = source.splitlines(keepends=True)
+        out: list[str] = []
+        changes: list[str] = []
+
+        for i, raw_line in enumerate(lines, start=1):
+            stripped = raw_line.lstrip(" \t")
+            already_commented = stripped.startswith("#")
+            ends_as_block_opener = raw_line.rstrip("\n").rstrip().endswith(":")
+            hit = (
+                None
+                if already_commented or ends_as_block_opener
+                else _tasks_hit(raw_line)
+            )
+
+            if hit:
+                indent = raw_line[: len(raw_line) - len(stripped)]
+                newline = "\n" if raw_line.endswith("\n") else ""
+                body = stripped.rstrip("\n")
+                todo_added = False
+
+                if not (out and out[-1].strip(" \t\n") == TODO):
+                    out.append(f"{indent}{TODO}{newline}")
+                    todo_added = True
+                if _safe_to_comment_out(raw_line):
+                    out.append(f"{indent}# {body}{newline}")
+                    changes.append(f"line {i}: commented out {hit}, added TODO")
+                elif todo_added:
+                    out.append(raw_line)
+                    changes.append(f"line {i}: added TODO for {hit}")
+                else:
+                    out.append(raw_line)
+            else:
+                out.append(raw_line)
+
+        new_text = "".join(out)
+        if not changes:
+            return self.unchanged(source)
+        return self.result(new_text, changes)

--- a/tests/test_fixers.py
+++ b/tests/test_fixers.py
@@ -39,7 +39,7 @@ def fix(name: str, source: str, path: str = "server.py"):
 # ---------------------------------------------------------------------------
 
 def test_ships_a_fixer_for_every_rule_the_task_calls_out():
-    assert {"R001", "R004", "R005", "R006", "R007", "R014", "R017"} <= FIXER_RULE_IDS
+    assert {"R001", "R004", "R005", "R006", "R007", "R014", "R017", "R019"} <= FIXER_RULE_IDS
 
 
 def test_every_fixer_has_a_valid_confidence_and_metadata():
@@ -417,6 +417,79 @@ def test_r014_leaves_event_store_append_logic_alone():
 def test_r014_idempotent():
     once = fix("SseResumabilityFixer", R014_BEFORE)
     twice = fix("SseResumabilityFixer", once.text)
+    assert twice.changed is False
+    assert twice.text == once.text
+
+
+# ---------------------------------------------------------------------------
+# R019 -- tasks/list and blocking tasks/result removed
+# ---------------------------------------------------------------------------
+
+R019_BEFORE = (
+    'from mcp.types import GetTaskPayloadRequest, ListTasksRequest\n'
+    '\n'
+    'async def wait_for_result(session, task_id: str):\n'
+    '    req = GetTaskPayloadRequest(taskId=task_id)\n'
+    '    return await session.send_request(req)\n'
+    '\n'
+    'METHODS = {"tasks/list": list_tasks, "tasks/result": blocking_result}\n'
+)
+R019_AFTER = (
+    '# TODO(mcp-migrate): tasks/list and blocking tasks/result are removed; '
+    'poll with tasks/get + tasks/update and declare io.modelcontextprotocol/tasks '
+    'under extensions — see https://modelcontextprotocol.io/specification/2026-07-28/changelog '
+    'and cookbook/11-tasks-polling.md\n'
+    '# from mcp.types import GetTaskPayloadRequest, ListTasksRequest\n'
+    '\n'
+    'async def wait_for_result(session, task_id: str):\n'
+    '    # TODO(mcp-migrate): tasks/list and blocking tasks/result are removed; '
+    'poll with tasks/get + tasks/update and declare io.modelcontextprotocol/tasks '
+    'under extensions — see https://modelcontextprotocol.io/specification/2026-07-28/changelog '
+    'and cookbook/11-tasks-polling.md\n'
+    '    # req = GetTaskPayloadRequest(taskId=task_id)\n'
+    '    return await session.send_request(req)\n'
+    '\n'
+    '# TODO(mcp-migrate): tasks/list and blocking tasks/result are removed; '
+    'poll with tasks/get + tasks/update and declare io.modelcontextprotocol/tasks '
+    'under extensions — see https://modelcontextprotocol.io/specification/2026-07-28/changelog '
+    'and cookbook/11-tasks-polling.md\n'
+    '# METHODS = {"tasks/list": list_tasks, "tasks/result": blocking_result}\n'
+)
+
+
+def test_r019_comments_out_sdk_types_and_wire_methods():
+    result = fix("TasksPollingFixer", R019_BEFORE)
+    assert result.changed
+    assert result.text == R019_AFTER
+    assert FIXERS["TasksPollingFixer"].confidence == "review"
+    ast.parse(result.text)
+
+
+def test_r019_skips_block_opener_handler_signatures():
+    before = (
+        "async def handle_tasks(request: ListTasksRequest):\n"
+        "    return []\n"
+    )
+    result = fix("TasksPollingFixer", before)
+    assert result.changed is False
+    assert result.text == before
+
+
+def test_r019_leaves_docstring_prose_alone():
+    before = (
+        '"""blocking tasks/list + tasks/result pair. Kept only as a migration example."""\n'
+        'METHODS = {"tasks/list": list_tasks}\n'
+    )
+    result = fix("TasksPollingFixer", before)
+    assert result.changed
+    assert before.splitlines()[0] in result.text
+    assert '# METHODS = {"tasks/list": list_tasks}' in result.text
+    ast.parse(result.text)
+
+
+def test_r019_idempotent():
+    once = fix("TasksPollingFixer", R019_BEFORE)
+    twice = fix("TasksPollingFixer", once.text)
     assert twice.changed is False
     assert twice.text == once.text
 


### PR DESCRIPTION
## Summary

Adds a `review`-confidence fixer for R019 that comments out lines referencing removed `tasks/list` and blocking `tasks/result` usage (SDK types and wire string literals) and leaves a TODO pointing at the spec and cookbook.

## Motivation

Issue #27 — blocking `tasks/result` cannot be mechanically rewritten into a polling loop, but flagged call sites benefit from the same TODO-annotation pattern used by R014.

## Changes

- New `TasksPollingFixer` in `src/mcp_migrate/fixers/r019_tasks_polling.py`
- Wire matching scoped to quoted `"tasks/list"` / `"tasks/result"` literals (not docstring prose)
- Tests: before/after transformation, block-opener skip, docstring prose guard, idempotency

## Tests

`python3 -m pytest tests/test_fixers.py -v` — 47/47 pass

## Notes

Handler signatures that end with `:` are intentionally left for human rewrite, matching R014.

Fixes #27