### PR TITLE
feat: Add R021 fixer – rewrite older JSON Schema dialect pins to 2020-12 (#29)

### DIFF
--- a/src/mcp_migrate/fixers/r021_json_schema_2020_12_required.py
+++ b/src/mcp_migrate/fixers/r021_json_schema_2020_12_required.py
@@ -1,0 +1,116 @@
+"""Fixer for R021 -- older JSON Schema dialect pin.
+
+SEP-2106 (2026-07-28) requires MCP implementations to support at least
+JSON Schema 2020-12 for inputSchema/outputSchema. Explicitly pinning an
+older draft (draft-07, 2019-09, etc.) via a ``$schema`` URL key is a
+mechanical, unambiguous rewrite: the old dialect URL string becomes the
+canonical 2020-12 URL.
+
+Confidence ``safe`` because:
+- The match is anchored to a ``"$schema"`` key on the same line, so the
+  regex cannot hit a comment, a log message, or an unrelated dialect
+  mention that just happens to contain the old URL string.
+- The transformation is an exact string substitution of the dialect
+  segment of the URL; no structural changes to the surrounding code.
+- When the pattern is ambiguous (e.g. the old dialect string appears on a
+  line that does *not* look like a ``"$schema"`` assignment), the fixer
+  backs off and leaves the line untouched rather than guess.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from .base import Fixer, FixResult
+
+# The authoritative 2020-12 $schema URL (no trailing #)
+_TARGET_DIALECT = "http://json-schema.org/draft/2020-12/schema"
+
+# Matches the old-dialect string only when it appears on the same line as
+# a "$schema": assignment (JSON, Python dict literal, YAML mapping, etc.).
+# The look-behind ensures there is a "$schema" key somewhere to the left;
+# the pattern then captures the old URL so we can replace just the URL
+# portion and leave surrounding quotes/whitespace intact.
+#
+# Matches:
+#   "$schema": "http://json-schema.org/draft-07/schema#"
+#   "$schema": "http://json-schema.org/draft-04/schema"
+#   "$schema": "https://json-schema.org/draft/2019-09/schema"
+#   "$schema" = "http://json-schema.org/draft-07/schema#"   (Python)
+#
+# Does NOT match:
+#   # old schema was draft-07         (no $schema key on the same line)
+#   some_other_key = "draft-07"       (no $schema key on the same line)
+_SCHEMA_KEY_RX = re.compile(
+    r"""
+    \"\$schema\"          # the "$schema" key (JSON / Python dict key)
+    \s*[:=]\s*            # colon (JSON/YAML) or equals (Python)
+    \"                    # opening quote of the value
+    (                     # capture group 1: the entire URL value we will replace
+        https?://
+        (?:json-schema\.org/draft-(?:0[1-7])/schema  # draft-01 through draft-07
+        |json-schema\.org/draft/2019-09/schema        # 2019-09 by path
+        )
+        [^"]*             # trailing fragment (#) or nothing
+    )
+    \"                    # closing quote
+    """,
+    re.VERBOSE,
+)
+
+# Also match bare 2019-09 mentions as a $schema value (some tools write
+# the short form: "$schema": "2019-09")
+_SCHEMA_KEY_SHORT_RX = re.compile(
+    r"""
+    \"\$schema\"
+    \s*[:=]\s*
+    \"
+    (2019-09|draft-0[1-7])   # short form dialect pins
+    \"
+    """,
+    re.VERBOSE,
+)
+
+# Guard: already the 2020-12 dialect -- do not touch these lines
+_ALREADY_2020_RX = re.compile(r"2020-12")
+
+
+class OldJSONSchemaDialectFixer(Fixer):
+    rule_id = "R021"
+    title = "Rewrite older JSON Schema dialect pin to 2020-12"
+    confidence = "safe"
+
+    def fix(self, source: str, path: Path) -> FixResult:
+        lines = source.splitlines(keepends=True)
+        changes: list[str] = []
+
+        for i, line in enumerate(lines):
+            # Already on 2020-12 -- skip (idempotency guard)
+            if _ALREADY_2020_RX.search(line):
+                continue
+
+            new_line = line
+
+            # Full URL form: replace captured URL with the target
+            m = _SCHEMA_KEY_RX.search(new_line)
+            if m:
+                new_line = new_line[: m.start(1)] + _TARGET_DIALECT + new_line[m.end(1) :]
+                changes.append(
+                    f"line {i + 1}: $schema dialect {m.group(1)!r} -> {_TARGET_DIALECT!r}"
+                )
+            else:
+                # Short form: replace the short dialect token with full URL
+                m2 = _SCHEMA_KEY_SHORT_RX.search(new_line)
+                if m2:
+                    new_line = (
+                        new_line[: m2.start(1)] + _TARGET_DIALECT + new_line[m2.end(1) :]
+                    )
+                    changes.append(
+                        f"line {i + 1}: $schema dialect {m2.group(1)!r} -> {_TARGET_DIALECT!r}"
+                    )
+
+            lines[i] = new_line
+
+        if not changes:
+            return self.unchanged(source)
+        return self.result("".join(lines), changes)

--- a/src/mcp_migrate/fixers/r021_json_schema_2020_12_required.py
+++ b/src/mcp_migrate/fixers/r021_json_schema_2020_12_required.py
@@ -24,7 +24,7 @@ from pathlib import Path
 from .base import Fixer, FixResult
 
 # The authoritative 2020-12 $schema URL (no trailing #)
-_TARGET_DIALECT = "http://json-schema.org/draft/2020-12/schema"
+_TARGET_DIALECT = "https://json-schema.org/draft/2020-12/schema"
 
 # Matches the old-dialect string only when it appears on the same line as
 # a "$schema": assignment (JSON, Python dict literal, YAML mapping, etc.).

--- a/tests/fixtures/fixer_roundtrip/server.py
+++ b/tests/fixtures/fixer_roundtrip/server.py
@@ -35,3 +35,12 @@ async def list_tools() -> list[Tool]:
         Tool(name="zeta", description="Last alphabetically."),
         Tool(name="alpha", description="First alphabetically."),
     ]
+
+# R021: old JSON Schema dialect pin -- the fixer must rewrite this
+TOOL_INPUT_SCHEMA = {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "properties": {
+        "name": {"type": "string"},
+    },
+}

--- a/tests/test_fixers.py
+++ b/tests/test_fixers.py
@@ -303,6 +303,75 @@ def test_r017_idempotent():
 
 
 # ---------------------------------------------------------------------------
+# R021 -- old JSON Schema dialect pin
+# ---------------------------------------------------------------------------
+
+_TARGET_DIALECT = "http://json-schema.org/draft/2020-12/schema"
+
+
+def test_r021_rewrites_draft07_url():
+    before = '"$schema": "http://json-schema.org/draft-07/schema#"\n'
+    result = fix("OldJSONSchemaDialectFixer", before)
+    assert result.changed
+    assert result.text == f'"$schema": "{_TARGET_DIALECT}"\n'
+    assert FIXERS["OldJSONSchemaDialectFixer"].confidence == "safe"
+
+
+def test_r021_rewrites_draft04_url():
+    before = '"$schema": "http://json-schema.org/draft-04/schema"\n'
+    result = fix("OldJSONSchemaDialectFixer", before)
+    assert result.changed
+    assert f'"{_TARGET_DIALECT}"' in result.text
+
+
+def test_r021_rewrites_2019_09_url():
+    before = '"$schema": "http://json-schema.org/draft/2019-09/schema"\n'
+    result = fix("OldJSONSchemaDialectFixer", before)
+    assert result.changed
+    assert f'"{_TARGET_DIALECT}"' in result.text
+
+
+def test_r021_rewrites_short_2019_09():
+    before = '"$schema": "2019-09"\n'
+    result = fix("OldJSONSchemaDialectFixer", before)
+    assert result.changed
+    assert f'"{_TARGET_DIALECT}"' in result.text
+
+
+def test_r021_leaves_ambiguous_comment_alone():
+    """A mention of draft-07 that is NOT inside a $schema assignment must not
+    be touched -- that would be a false positive and silent corruption."""
+    before = "# Previously used draft-07 schema dialect\n"
+    result = fix("OldJSONSchemaDialectFixer", before)
+    assert result.changed is False
+    assert result.text == before
+
+
+def test_r021_leaves_unrelated_key_alone():
+    """An old dialect string in a value keyed by something other than $schema
+    must not be rewritten -- the fixer cannot know what that string means."""
+    before = '"description": "http://json-schema.org/draft-07/schema#"\n'
+    result = fix("OldJSONSchemaDialectFixer", before)
+    assert result.changed is False
+    assert result.text == before
+
+
+def test_r021_idempotent():
+    before = '"$schema": "http://json-schema.org/draft-07/schema#"\n'
+    once = fix("OldJSONSchemaDialectFixer", before)
+    twice = fix("OldJSONSchemaDialectFixer", once.text)
+    assert twice.changed is False
+    assert twice.text == once.text
+
+
+def test_r021_already_2020_12_is_unchanged():
+    before = f'"$schema": "{_TARGET_DIALECT}"\n'
+    result = fix("OldJSONSchemaDialectFixer", before)
+    assert result.changed is False
+    assert result.text == before
+
+
+# ---------------------------------------------------------------------------
 # CLI: fix / fixers
 # ---------------------------------------------------------------------------
 

--- a/tests/test_fixers.py
+++ b/tests/test_fixers.py
@@ -306,14 +306,14 @@ def test_r017_idempotent():
 # R021 -- old JSON Schema dialect pin
 # ---------------------------------------------------------------------------
 
-_TARGET_DIALECT = "http://json-schema.org/draft/2020-12/schema"
+_TARGET_DIALECT = "https://json-schema.org/draft/2020-12/schema"
 
 
 def test_r021_rewrites_draft07_url():
     before = '"$schema": "http://json-schema.org/draft-07/schema#"\n'
     result = fix("OldJSONSchemaDialectFixer", before)
     assert result.changed
-    assert result.text == f'"$schema": "{_TARGET_DIALECT}"\n'
+    assert result.text == '"$schema": "https://json-schema.org/draft/2020-12/schema"\n'
     assert FIXERS["OldJSONSchemaDialectFixer"].confidence == "safe"
 
 


### PR DESCRIPTION
Closes #29

## Summary

Adds a `safe`-confidence `Fixer` subclass (`OldJSONSchemaDialectFixer`) for **R021** — the rule that flags explicit older JSON Schema dialect pins (`draft-07`, `2019-09`, etc.).

## What the fixer does

Scans each line for a `"$schema"` key assignment containing an older dialect URL or short token, and rewrites it to the canonical 2020-12 URL:

```
- "$schema": "http://json-schema.org/draft-07/schema#"
+ "$schema": "http://json-schema.org/draft/2020-12/schema"
```

The rewrite is anchored to a `"$schema":` key on the same line — so comments, log messages, or values under a different key that merely _contain_ the old URL string are deliberately left untouched.

## Confidence: `safe`

- Transformation is an exact string substitution; no AST round-tripping
- Match requires the `"$schema"` key to be visible on the same line → no false-positive risk from ambient mentions
- Already-2020-12 lines are skipped (idempotency guard)

## Files changed

| File | Purpose |
|---|---|
| `src/mcp_migrate/fixers/r021_json_schema_2020_12_required.py` | New `OldJSONSchemaDialectFixer` class (auto-discovered) |
| `tests/test_fixers.py` | 8 new test cases: draft-07 URL, draft-04 URL, 2019-09 URL, short form, comment left alone, wrong key left alone, idempotency, already-2020-12 unchanged |
| `tests/fixtures/fixer_roundtrip/server.py` | Added a `$schema draft-07` pin so the fixer round-trip test exercises R021 |

## Tests

All 233 tests pass (`python3 -m pytest -q`). The fixer file passes `ruff check` clean.