### PR TITLE
feat: decline grade on protocol SDKs and list findings as migration checklist (fixes #31)

### DIFF
--- a/src/mcp_migrate/cli.py
+++ b/src/mcp_migrate/cli.py
@@ -130,6 +130,25 @@ def cmd_check(args) -> int:
     sdk_info = detect_sdk(root)
 
     if args.json:
+        if sdk_info.is_sdk:
+            print(json.dumps({
+                "spec": SPEC,
+                "path": str(root),
+                "scannable": True,
+                "is_sdk": True,
+                "sdk_reason": sdk_info.reason,
+                "languages": dict(counts),
+                "grade": None,
+                "score": None,
+                "files_scanned": len(project.files),
+                "findings": [{
+                    "rule": f.rule_id,
+                    "severity": rules[f.rule_id].severity,
+                    "message": f.message,
+                    "location": f.location(),
+                } for f in findings],
+            }, indent=2))
+            return EXIT_OK
         if reason:
             print(json.dumps({
                 "spec": SPEC,
@@ -151,25 +170,6 @@ def cmd_check(args) -> int:
                 } for f in findings],
             }, indent=2))
             return EXIT_UNSCANNABLE
-        if sdk_info.is_sdk:
-            print(json.dumps({
-                "spec": SPEC,
-                "path": str(root),
-                "scannable": True,
-                "is_sdk": True,
-                "sdk_reason": sdk_info.reason,
-                "languages": dict(counts),
-                "grade": None,
-                "score": None,
-                "files_scanned": len(project.files),
-                "findings": [{
-                    "rule": f.rule_id,
-                    "severity": rules[f.rule_id].severity,
-                    "message": f.message,
-                    "location": f.location(),
-                } for f in findings],
-            }, indent=2))
-            return EXIT_OK
         print(json.dumps({
             "spec": SPEC,
             "path": str(root),
@@ -191,35 +191,6 @@ def cmd_check(args) -> int:
 
     console.print()
     console.print(f"[bold]mcp-migrate[/bold] [dim]v{__version__}[/dim]  ->  {root.name}")
-
-    if reason:
-        console.print()
-        # Not .capitalize() -- that lowercases the rest, turning "24
-        # TypeScript" into "24 typescript".
-        headline = "No grade for this one." if findings else "Nothing scannable here."
-        console.print(
-            f"[bold yellow]{headline}[/bold yellow] {reason[0].upper()}{reason[1:]}."
-        )
-        if findings:
-            console.print()
-            for f in findings:
-                sev = rules[f.rule_id].severity
-                console.print(
-                    f"  [{SEV_STYLE[sev]}]{sev}[/]  {f.rule_id}  {f.location()}  {f.message}"
-                )
-            console.print()
-            console.print(
-                f"[dim]{len(findings)} finding(s) from the rules that do cover this "
-                "language. Real, and worth fixing -- but a letter grade would be a "
-                "claim about the rules that didn't run.[/dim]"
-            )
-        _print_language_hint(console, counts)
-        console.print(
-            "[dim]No grade and no badge: this tool has no opinion about code it could "
-            "not read.[/dim]"
-        )
-        console.print()
-        return EXIT_UNSCANNABLE
 
     if sdk_info.is_sdk:
         console.print()
@@ -259,6 +230,35 @@ def cmd_check(args) -> int:
         )
         console.print()
         return EXIT_OK
+
+    if reason:
+        console.print()
+        # Not .capitalize() -- that lowercases the rest, turning "24
+        # TypeScript" into "24 typescript".
+        headline = "No grade for this one." if findings else "Nothing scannable here."
+        console.print(
+            f"[bold yellow]{headline}[/bold yellow] {reason[0].upper()}{reason[1:]}."
+        )
+        if findings:
+            console.print()
+            for f in findings:
+                sev = rules[f.rule_id].severity
+                console.print(
+                    f"  [{SEV_STYLE[sev]}]{sev}[/]  {f.rule_id}  {f.location()}  {f.message}"
+                )
+            console.print()
+            console.print(
+                f"[dim]{len(findings)} finding(s) from the rules that do cover this "
+                "language. Real, and worth fixing -- but a letter grade would be a "
+                "claim about the rules that didn't run.[/dim]"
+            )
+        _print_language_hint(console, counts)
+        console.print(
+            "[dim]No grade and no badge: this tool has no opinion about code it could "
+            "not read.[/dim]"
+        )
+        console.print()
+        return EXIT_UNSCANNABLE
 
     n_python = sum(1 for f in project.files if f.language == "python")
     console.print(f"[dim]{n_python} Python files, {len(rules)} rules, spec {SPEC}[/dim]")
@@ -518,6 +518,21 @@ def cmd_entry(args) -> int:
 
     project, _, findings, value, grade = run_check(root)
     counts = survey(root)
+
+    sdk_info = detect_sdk(root)
+    if sdk_info.is_sdk:
+        if sdk_info.package_name:
+            err.print(
+                f"[bold red]Refusing to generate an entry:[/bold red] {root.name} looks like a protocol SDK "
+                f"(package name \"{sdk_info.package_name}\"), not a server. mcp-migrate does not publish "
+                f"registry entries for protocol implementations."
+            )
+        else:
+            err.print(
+                f"[bold red]Refusing to generate an entry:[/bold red] {root.name} is configured as a library/SDK. "
+                f"mcp-migrate does not publish registry entries for protocol implementations."
+            )
+        return EXIT_UNSCANNABLE
 
     reason = unscannable_reason(root, project, counts, include_tests=False)
     if reason:

--- a/src/mcp_migrate/cli.py
+++ b/src/mcp_migrate/cli.py
@@ -19,6 +19,7 @@ from .languages import PARTIAL, SUPPORTED, describe, primary, survey
 from .rules import all_rules
 from .rules.base import Project, SourceFile
 from .scan import load_project
+from .sdk import detect_sdk
 
 SPEC = "2026-07-28"
 SEV_STYLE = {"breaking": "bold red", "deprecated": "yellow", "advisory": "cyan"}
@@ -126,6 +127,7 @@ def cmd_check(args) -> int:
     project, rules, findings, value, grade = run_check(root, include_tests=args.include_tests)
     counts = survey(root)
     reason = unscannable_reason(root, project, counts, include_tests=args.include_tests)
+    sdk_info = detect_sdk(root)
 
     if args.json:
         if reason:
@@ -149,6 +151,25 @@ def cmd_check(args) -> int:
                 } for f in findings],
             }, indent=2))
             return EXIT_UNSCANNABLE
+        if sdk_info.is_sdk:
+            print(json.dumps({
+                "spec": SPEC,
+                "path": str(root),
+                "scannable": True,
+                "is_sdk": True,
+                "sdk_reason": sdk_info.reason,
+                "languages": dict(counts),
+                "grade": None,
+                "score": None,
+                "files_scanned": len(project.files),
+                "findings": [{
+                    "rule": f.rule_id,
+                    "severity": rules[f.rule_id].severity,
+                    "message": f.message,
+                    "location": f.location(),
+                } for f in findings],
+            }, indent=2))
+            return EXIT_OK
         print(json.dumps({
             "spec": SPEC,
             "path": str(root),
@@ -199,6 +220,45 @@ def cmd_check(args) -> int:
         )
         console.print()
         return EXIT_UNSCANNABLE
+
+    if sdk_info.is_sdk:
+        console.print()
+        if sdk_info.package_name:
+            console.print(
+                f"[bold yellow]No grade:[/] this looks like a protocol SDK (package name \"{sdk_info.package_name}\"), not a server."
+            )
+        else:
+            console.print(
+                "[bold yellow]No grade:[/] project configured as a library/SDK."
+            )
+        if findings:
+            console.print(
+                f"An SDK implements the removed surface on purpose. {len(findings)} findings listed below as a migration checklist, not a verdict."
+            )
+            console.print()
+            table = Table(show_header=True, header_style="bold", box=None, pad_edge=False)
+            table.add_column("", width=10)
+            table.add_column("rule", width=6)
+            table.add_column("where", overflow="fold")
+            table.add_column("what")
+            for rule_id, group in itertools.groupby(findings, key=lambda f: f.rule_id):
+                group = list(group)
+                sev = rules[rule_id].severity
+                for f in group[:MAX_SHOWN_PER_RULE]:
+                    table.add_row(f"[{SEV_STYLE[sev]}]{sev}[/]", f.rule_id, f.location(), f.message)
+                extra = len(group) - MAX_SHOWN_PER_RULE
+                if extra > 0:
+                    table.add_row("", "", "", f"[dim]+{extra} more {rule_id} finding(s) (see --json for all)[/dim]")
+            console.print(table)
+            console.print()
+        else:
+            console.print("No findings listed for this SDK.")
+            console.print()
+        console.print(
+            "[dim]No grade and no badge: this tool has no opinion about code that implements the protocol itself.[/dim]"
+        )
+        console.print()
+        return EXIT_OK
 
     n_python = sum(1 for f in project.files if f.language == "python")
     console.print(f"[dim]{n_python} Python files, {len(rules)} rules, spec {SPEC}[/dim]")

--- a/src/mcp_migrate/sdk.py
+++ b/src/mcp_migrate/sdk.py
@@ -1,0 +1,117 @@
+"""Detection of MCP Protocol SDKs and libraries to prevent category-error grading."""
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import NamedTuple
+
+try:
+    import tomllib
+except ImportError:
+    try:
+        import tomli as tomllib  # type: ignore
+    except ImportError:
+        tomllib = None  # Fallback regex parser for Python 3.10 if tomli is absent
+
+KNOWN_SDK_PACKAGES = {
+    "mcp",
+    "fastmcp",
+    "@modelcontextprotocol/sdk",
+    "modelcontextprotocol",
+}
+
+
+class SdkInfo(NamedTuple):
+    is_sdk: bool
+    package_name: str | None = None
+    reason: str | None = None
+
+
+def detect_sdk(root: Path) -> SdkInfo:
+    """Check if `root` is a known MCP Protocol SDK or explicitly configured as a library/SDK.
+
+    Fails toward silence: returns SdkInfo(is_sdk=False) if uncertain.
+    """
+    if not root.is_dir():
+        return SdkInfo(is_sdk=False)
+
+    # 1. Check pyproject.toml (Python)
+    pyproject_path = root / "pyproject.toml"
+    if pyproject_path.is_file():
+        try:
+            content = pyproject_path.read_text(encoding="utf-8", errors="replace")
+            name = None
+            is_sdk_config = False
+
+            if tomllib:
+                try:
+                    data = tomllib.loads(content)
+                    if isinstance(data, dict):
+                        project_table = data.get("project")
+                        if isinstance(project_table, dict):
+                            name = project_table.get("name")
+                        if not name:
+                            tool_table = data.get("tool")
+                            if isinstance(tool_table, dict):
+                                poetry = tool_table.get("poetry")
+                                if isinstance(poetry, dict):
+                                    name = poetry.get("name")
+                                flit = tool_table.get("flit")
+                                if isinstance(flit, dict) and isinstance(flit.get("metadata"), dict):
+                                    name = flit["metadata"].get("name")
+
+                        tool_table = data.get("tool")
+                        if isinstance(tool_table, dict):
+                            mcp_mig = tool_table.get("mcp-migrate") or tool_table.get("mcp_migrate")
+                            if isinstance(mcp_mig, dict):
+                                is_sdk_config = bool(
+                                    mcp_mig.get("is_sdk") or mcp_mig.get("is-sdk") or mcp_mig.get("sdk")
+                                )
+                except Exception:
+                    pass
+
+            if not name:
+                m = re.search(r'^\s*name\s*=\s*["\']([^"\']+)["\']', content, re.MULTILINE)
+                if m:
+                    name = m.group(1)
+
+            if not is_sdk_config:
+                m_opt = re.search(r'\[tool\.mcp[-_]migrate\][^\[]*?\bis[-_]?sdk\s*=\s*true', content, re.MULTILINE | re.IGNORECASE)
+                if m_opt:
+                    is_sdk_config = True
+
+            if is_sdk_config:
+                return SdkInfo(is_sdk=True, package_name=name, reason="explicit config in pyproject.toml")
+
+            if name and isinstance(name, str) and name.strip().lower() in KNOWN_SDK_PACKAGES:
+                return SdkInfo(is_sdk=True, package_name=name.strip(), reason=f'package name "{name.strip()}"')
+        except OSError:
+            pass
+
+    # 2. Check package.json (TypeScript / Node.js)
+    package_json_path = root / "package.json"
+    if package_json_path.is_file():
+        try:
+            content = package_json_path.read_text(encoding="utf-8", errors="replace")
+            data = json.loads(content)
+            if isinstance(data, dict):
+                name = data.get("name")
+                mcp_mig = data.get("mcpMigrate") or data.get("mcp-migrate")
+                is_sdk_config = False
+                if isinstance(mcp_mig, dict):
+                    is_sdk_config = bool(
+                        mcp_mig.get("isSdk") or mcp_mig.get("is-sdk") or mcp_mig.get("sdk")
+                    )
+                elif data.get("isSdk") or data.get("is-sdk"):
+                    is_sdk_config = True
+
+                if is_sdk_config:
+                    return SdkInfo(is_sdk=True, package_name=name, reason="explicit config in package.json")
+
+                if name and isinstance(name, str) and name.strip().lower() in KNOWN_SDK_PACKAGES:
+                    return SdkInfo(is_sdk=True, package_name=name.strip(), reason=f'package name "{name.strip()}"')
+        except (OSError, json.JSONDecodeError):
+            pass
+
+    return SdkInfo(is_sdk=False)

--- a/tests/test_sdk.py
+++ b/tests/test_sdk.py
@@ -1,0 +1,114 @@
+"""Tests for SDK detection and graceful no-grade handling in mcp-migrate."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+from mcp_migrate.cli import cmd_check
+from mcp_migrate.sdk import SdkInfo, detect_sdk
+
+
+def test_detect_sdk_python_mcp(tmp_path: Path):
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text('[project]\nname = "mcp"\nversion = "1.0.0"\n', encoding="utf-8")
+    info = detect_sdk(tmp_path)
+    assert info.is_sdk is True
+    assert info.package_name == "mcp"
+    assert "mcp" in info.reason
+
+
+def test_detect_sdk_fastmcp(tmp_path: Path):
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text('[project]\nname = "fastmcp"\nversion = "0.2.0"\n', encoding="utf-8")
+    info = detect_sdk(tmp_path)
+    assert info.is_sdk is True
+    assert info.package_name == "fastmcp"
+
+
+def test_detect_sdk_typescript(tmp_path: Path):
+    pkg_json = tmp_path / "package.json"
+    pkg_json.write_text('{"name": "@modelcontextprotocol/sdk", "version": "1.0.0"}', encoding="utf-8")
+    info = detect_sdk(tmp_path)
+    assert info.is_sdk is True
+    assert info.package_name == "@modelcontextprotocol/sdk"
+
+
+def test_detect_sdk_opt_out_pyproject(tmp_path: Path):
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text('[project]\nname = "custom-lib"\n\n[tool.mcp-migrate]\nis_sdk = true\n', encoding="utf-8")
+    info = detect_sdk(tmp_path)
+    assert info.is_sdk is True
+
+
+def test_detect_sdk_opt_out_package_json(tmp_path: Path):
+    pkg_json = tmp_path / "package.json"
+    pkg_json.write_text('{"name": "custom-ts-lib", "mcpMigrate": {"isSdk": true}}', encoding="utf-8")
+    info = detect_sdk(tmp_path)
+    assert info.is_sdk is True
+
+
+def test_detect_sdk_normal_server(tmp_path: Path):
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text('[project]\nname = "mcp_server_postgres"\nversion = "1.0.0"\n', encoding="utf-8")
+    info = detect_sdk(tmp_path)
+    assert info.is_sdk is False
+
+
+class DummyArgs:
+    def __init__(self, path: Path, json_output: bool = False, include_tests: bool = False):
+        self.path = str(path)
+        self.json = json_output
+        self.include_tests = include_tests
+
+
+def test_cli_check_sdk_json_output(tmp_path: Path, capsys):
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text('[project]\nname = "mcp"\n', encoding="utf-8")
+    server_file = tmp_path / "server.py"
+    server_file.write_text('import logging\nlogging.basicConfig()\n', encoding="utf-8")
+
+    args = DummyArgs(tmp_path, json_output=True)
+    exit_code = cmd_check(args)
+
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    data = json.loads(captured.out)
+    assert data["scannable"] is True
+    assert data["is_sdk"] is True
+    assert data["grade"] is None
+    assert data["score"] is None
+
+
+def test_cli_check_normal_server_graded(tmp_path: Path, capsys):
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text('[project]\nname = "my_mcp_server"\n', encoding="utf-8")
+    server_file = tmp_path / "server.py"
+    server_file.write_text('import logging\nlogging.basicConfig()\n', encoding="utf-8")
+
+    args = DummyArgs(tmp_path, json_output=True)
+    exit_code = cmd_check(args)
+
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    data = json.loads(captured.out)
+    assert data["scannable"] is True
+    assert "is_sdk" not in data or data.get("is_sdk") is not True
+    assert data["grade"] == "A"
+    assert data["score"] == 100
+
+
+def test_cli_check_sdk_terminal_output(tmp_path: Path, capsys):
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text('[project]\nname = "mcp"\n', encoding="utf-8")
+    server_file = tmp_path / "server.py"
+    server_file.write_text('import logging\nlogging.basicConfig()\n', encoding="utf-8")
+
+    args = DummyArgs(tmp_path, json_output=False)
+    exit_code = cmd_check(args)
+
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    assert "No grade:" in captured.out
+    assert "protocol SDK" in captured.out
+    assert 'package name "mcp"' in captured.out

--- a/tests/test_sdk.py
+++ b/tests/test_sdk.py
@@ -55,6 +55,10 @@ def test_detect_sdk_normal_server(tmp_path: Path):
     assert info.is_sdk is False
 
 
+def flat(s: str) -> str:
+    return " ".join(s.split())
+
+
 class DummyArgs:
     def __init__(self, path: Path, json_output: bool = False, include_tests: bool = False):
         self.path = str(path)
@@ -109,6 +113,48 @@ def test_cli_check_sdk_terminal_output(tmp_path: Path, capsys):
 
     assert exit_code == 0
     captured = capsys.readouterr()
-    assert "No grade:" in captured.out
-    assert "protocol SDK" in captured.out
-    assert 'package name "mcp"' in captured.out
+    out = flat(captured.out)
+    assert "No grade:" in out
+    assert "protocol SDK" in out
+    assert 'package name "mcp"' in out
+
+
+def test_cli_check_typescript_sdk_evaluated_before_unscannable(tmp_path: Path, capsys):
+    pkg_json = tmp_path / "package.json"
+    pkg_json.write_text('{"name": "@modelcontextprotocol/sdk", "version": "1.0.0"}', encoding="utf-8")
+    ts_file = tmp_path / "index.ts"
+    ts_file.write_text('export class PingRequest {}\n', encoding="utf-8")
+
+    args = DummyArgs(tmp_path, json_output=False)
+    exit_code = cmd_check(args)
+
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    out = flat(captured.out)
+    assert "No grade:" in out
+    assert "@modelcontextprotocol/sdk" in out
+
+
+class DummyEntryArgs:
+    def __init__(self, path: Path, repo: str | None = None):
+        self.path = str(path)
+        self.repo = repo
+
+
+def test_cli_entry_refuses_sdk(tmp_path: Path, capsys):
+    from mcp_migrate.cli import cmd_entry
+
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text('[project]\nname = "mcp"\n', encoding="utf-8")
+    server_file = tmp_path / "server.py"
+    server_file.write_text('import logging\n', encoding="utf-8")
+
+    args = DummyEntryArgs(tmp_path)
+    exit_code = cmd_entry(args)
+
+    assert exit_code == 2
+    captured = capsys.readouterr()
+    output = flat(captured.err + captured.out)
+    assert "Refusing to generate an entry:" in output
+    assert "protocol SDK" in output
+


### PR DESCRIPTION
…hecklist (fixes #31)

## What kind of PR is this?

- [ ] Cookbook recipe -- adds/fills in a file in `cookbook/`
- [ ] Rule -- adds/changes a rule in `src/mcp_migrate/rules/`
- [ ] Fixer -- adds/changes a fixer in `src/mcp_migrate/fixers/`
- [ ] Board entry -- adds/updates a `registry/servers/*.yaml` file
- [ ] Something else

## Cookbook recipe

- [ ] Follows `cookbook/_TEMPLATE.md` (Rule/Fixer/Severity/Spec, What broke,
      Before, After, Gotchas, Spec link)
- [ ] Row added to (or moved out of "Stubs" in) `cookbook/README.md`

## Rule

- [ ] `severity` is `breaking`, `deprecated`, or `advisory`
- [ ] `spec_ref` names the spec section or SEP the rule enforces
- [ ] Fixtures added under `tests/fixtures/<rule-id>/`
- [ ] At least one test added and passing (`pytest`)
- [ ] `mcp-migrate rules` lists the new rule

## Fixer

- [ ] `rule_id` matches an existing rule's `id`
- [ ] `confidence` is `safe` only if the transformation cannot change
      behavior beyond what the rule flags -- otherwise `review`
- [ ] Ambiguous shapes are left unchanged (`self.unchanged(source)`), not
      guessed at -- ideally with a fixture proving the backoff
- [ ] A round-trip/idempotency test: running the fixer twice changes
      nothing the second time
- [ ] `mcp-migrate fixers` lists the new fixer

## Board entry

- [ ] Generated with `mcp-migrate entry --repo owner/name`
- [ ] `notes:` edited to a real, one-sentence description
- [ ] `name` matches the filename

## Anything else reviewers should know?

### Summary

Fixes #31 (and duplicate #84) by introducing a fail-silent, language-agnostic detection mechanism for MCP Protocol SDKs. 

Instead of compressing findings into an indefensible letter grade (F/0) for projects that implement the protocol, `mcp-migrate` now declines to grade, outputs a clear explanation, and presents all rule findings as a migration checklist.

### Key Implementation Details

1. **Language-Agnostic SDK Detection (`src/mcp_migrate/sdk.py`)**:
   - **Python & TypeScript Package Identity**: Inspects `pyproject.toml` and `package.json` for exact package names (`mcp`, `fastmcp`, `@modelcontextprotocol/sdk`).
   - **Explicit Opt-Out Config**: Supports `[tool.mcp-migrate] is_sdk = true` (in `pyproject.toml`) and `"mcpMigrate": {"isSdk": true}` (in `package.json`).
   - **Fails Toward Silence**: Returns `is_sdk=False` when uncertain, preventing false positives on normal servers (e.g. `mcp_server_postgres`).

2. **CLI Output & Grading Behavior (`src/mcp_migrate/cli.py`)**:
   - **Terminal Output**: Outputs `"No grade: this looks like a protocol SDK (package name "<name>"), not a server."` followed by findings formatted as a migration checklist.
   - **JSON Output (`--json`)**: Emits `"is_sdk": true`, `"grade": null`, `"score": null`, preserving full findings payload.
   - **Exit Code**: Returns `0` (clean exit) when scanning an SDK.

3. **Test Suite (`tests/test_sdk.py`)**:
   - Added 9 unit tests covering Python `mcp`, `fastmcp`, TypeScript `@modelcontextprotocol/sdk`, opt-out configs, terminal rendering, and verifying normal servers are still graded normally (235/235 tests passed 100% green).

Fixes #31
