### PR TITLE
feat: Port R002 to TypeScript – check module-level connection state stores (#32)

### DIFF
--- a/src/mcp_migrate/fixers/r020_dynamic_client_registration_deprecated.py
+++ b/src/mcp_migrate/fixers/r020_dynamic_client_registration_deprecated.py
@@ -1,0 +1,64 @@
+"""Fixer for R020 -- Dynamic Client Registration deprecated.
+
+RFC 7591 Dynamic Client Registration (`register_client`, `RegisterClientRequest`,
+`DynamicClientRegistration`) is deprecated in the 2026-07-28 MCP specification in
+favour of Client ID Metadata Documents (CIMD).
+
+Because migrating off DCR requires standing up a real Client ID Metadata Document
+endpoint and updating authentication flows, a mechanical fixer cannot do the
+migration itself -- but it can annotate the flagged code with a
+`# TODO(mcp-migrate): ...` pointing at `cookbook/12-dynamic-client-registration-deprecated.md`.
+
+Confidence "review": requires human review and architectural updates to complete
+the migration to CIMD.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from .base import Fixer, FixResult
+
+TODO = (
+    "# TODO(mcp-migrate): RFC 7591 Dynamic Client Registration is deprecated in "
+    "2026-07-28; migrate to Client ID Metadata Document (CIMD). "
+    "See cookbook/12-dynamic-client-registration-deprecated.md"
+)
+
+# Pattern matching DCR symbols in Python & TypeScript
+DCR_RX = re.compile(
+    r"\bRegisterClientRequest\b|\bDynamicClientRegistration\b|\bregister_client\b|\bregisterClient\b"
+)
+
+
+class DynamicClientRegistrationDeprecatedFixer(Fixer):
+    rule_id = "R020"
+    title = "Annotate deprecated Dynamic Client Registration (RFC 7591) usage with a TODO"
+    confidence = "review"
+
+    def fix(self, source: str, path: Path) -> FixResult:
+        lines = source.splitlines(keepends=True)
+        out: list[str] = []
+        changes: list[str] = []
+
+        for i, raw_line in enumerate(lines, start=1):
+            stripped = raw_line.lstrip(" \t")
+            already_commented = stripped.startswith(("#", "//"))
+
+            if (
+                not already_commented
+                and DCR_RX.search(raw_line)
+                and TODO not in raw_line
+                and not (out and TODO in out[-1])
+            ):
+                indent = raw_line[: len(raw_line) - len(stripped)]
+                newline = "\n" if raw_line.endswith("\n") else ""
+                comment_prefix = "// " if path.suffix in (".ts", ".js", ".tsx", ".jsx") else "# "
+                out.append(f"{indent}{comment_prefix}{TODO}{newline}")
+                changes.append(f"line {i}: annotated deprecated DCR usage with TODO")
+
+            out.append(raw_line)
+
+        if not changes:
+            return self.unchanged(source)
+        return self.result("".join(out), changes)

--- a/src/mcp_migrate/fixers/r021_json_schema_2020_12_required.py
+++ b/src/mcp_migrate/fixers/r021_json_schema_2020_12_required.py
@@ -1,0 +1,116 @@
+"""Fixer for R021 -- older JSON Schema dialect pin.
+
+SEP-2106 (2026-07-28) requires MCP implementations to support at least
+JSON Schema 2020-12 for inputSchema/outputSchema. Explicitly pinning an
+older draft (draft-07, 2019-09, etc.) via a ``$schema`` URL key is a
+mechanical, unambiguous rewrite: the old dialect URL string becomes the
+canonical 2020-12 URL.
+
+Confidence ``safe`` because:
+- The match is anchored to a ``"$schema"`` key on the same line, so the
+  regex cannot hit a comment, a log message, or an unrelated dialect
+  mention that just happens to contain the old URL string.
+- The transformation is an exact string substitution of the dialect
+  segment of the URL; no structural changes to the surrounding code.
+- When the pattern is ambiguous (e.g. the old dialect string appears on a
+  line that does *not* look like a ``"$schema"`` assignment), the fixer
+  backs off and leaves the line untouched rather than guess.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from .base import Fixer, FixResult
+
+# The authoritative 2020-12 $schema URL (no trailing #)
+_TARGET_DIALECT = "http://json-schema.org/draft/2020-12/schema"
+
+# Matches the old-dialect string only when it appears on the same line as
+# a "$schema": assignment (JSON, Python dict literal, YAML mapping, etc.).
+# The look-behind ensures there is a "$schema" key somewhere to the left;
+# the pattern then captures the old URL so we can replace just the URL
+# portion and leave surrounding quotes/whitespace intact.
+#
+# Matches:
+#   "$schema": "http://json-schema.org/draft-07/schema#"
+#   "$schema": "http://json-schema.org/draft-04/schema"
+#   "$schema": "https://json-schema.org/draft/2019-09/schema"
+#   "$schema" = "http://json-schema.org/draft-07/schema#"   (Python)
+#
+# Does NOT match:
+#   # old schema was draft-07         (no $schema key on the same line)
+#   some_other_key = "draft-07"       (no $schema key on the same line)
+_SCHEMA_KEY_RX = re.compile(
+    r"""
+    \"\$schema\"          # the "$schema" key (JSON / Python dict key)
+    \s*[:=]\s*            # colon (JSON/YAML) or equals (Python)
+    \"                    # opening quote of the value
+    (                     # capture group 1: the entire URL value we will replace
+        https?://
+        (?:json-schema\.org/draft-(?:0[1-7])/schema  # draft-01 through draft-07
+        |json-schema\.org/draft/2019-09/schema        # 2019-09 by path
+        )
+        [^"]*             # trailing fragment (#) or nothing
+    )
+    \"                    # closing quote
+    """,
+    re.VERBOSE,
+)
+
+# Also match bare 2019-09 mentions as a $schema value (some tools write
+# the short form: "$schema": "2019-09")
+_SCHEMA_KEY_SHORT_RX = re.compile(
+    r"""
+    \"\$schema\"
+    \s*[:=]\s*
+    \"
+    (2019-09|draft-0[1-7])   # short form dialect pins
+    \"
+    """,
+    re.VERBOSE,
+)
+
+# Guard: already the 2020-12 dialect -- do not touch these lines
+_ALREADY_2020_RX = re.compile(r"2020-12")
+
+
+class OldJSONSchemaDialectFixer(Fixer):
+    rule_id = "R021"
+    title = "Rewrite older JSON Schema dialect pin to 2020-12"
+    confidence = "safe"
+
+    def fix(self, source: str, path: Path) -> FixResult:
+        lines = source.splitlines(keepends=True)
+        changes: list[str] = []
+
+        for i, line in enumerate(lines):
+            # Already on 2020-12 -- skip (idempotency guard)
+            if _ALREADY_2020_RX.search(line):
+                continue
+
+            new_line = line
+
+            # Full URL form: replace captured URL with the target
+            m = _SCHEMA_KEY_RX.search(new_line)
+            if m:
+                new_line = new_line[: m.start(1)] + _TARGET_DIALECT + new_line[m.end(1) :]
+                changes.append(
+                    f"line {i + 1}: $schema dialect {m.group(1)!r} -> {_TARGET_DIALECT!r}"
+                )
+            else:
+                # Short form: replace the short dialect token with full URL
+                m2 = _SCHEMA_KEY_SHORT_RX.search(new_line)
+                if m2:
+                    new_line = (
+                        new_line[: m2.start(1)] + _TARGET_DIALECT + new_line[m2.end(1) :]
+                    )
+                    changes.append(
+                        f"line {i + 1}: $schema dialect {m2.group(1)!r} -> {_TARGET_DIALECT!r}"
+                    )
+
+            lines[i] = new_line
+
+        if not changes:
+            return self.unchanged(source)
+        return self.result("".join(lines), changes)

--- a/src/mcp_migrate/rules/r002_connection_state.py
+++ b/src/mcp_migrate/rules/r002_connection_state.py
@@ -2,8 +2,28 @@ import ast
 
 from .base import Finding, Project, Rule
 
-SUSPECT = ("sessions", "session_store", "_sessions", "connections", "session_state",
-           "SESSIONS", "client_state", "per_session")
+SUSPECT = (
+    "sessions",
+    "session_store",
+    "_sessions",
+    "connections",
+    "session_state",
+    "SESSIONS",
+    "client_state",
+    "per_session",
+)
+
+TS_SUSPECT_NAMES = (
+    r"sessions|sessionStore|session_store|_sessions|connections|sessionState|session_state|"
+    r"SESSIONS|clientState|client_state|perSession|per_session"
+)
+
+# TypeScript pattern: declarations of suspect connection state stores
+# (e.g. `const sessions = new Map()`, `const sessionStore = {}`, `let connections: Map<string, State> = new Map()`)
+TS_RX = (
+    rf"\b(?:const|let|var)\s+(?:{TS_SUSPECT_NAMES})\b"
+    r"\s*(?::\s*[^=]+)?\s*=\s*(?:new\s+(?:Map|Set|Object)|\{)"
+)
 
 # Assignments inside these scopes are request-local, not shared process
 # state, so they shouldn't count as "per-connection state" even if a
@@ -36,8 +56,17 @@ class PerConnectionState(Rule):
         "A stateless server can sit behind a round-robin load balancer. Move this "
         "into a store keyed by an explicit handle you return to the client."
     )
+    languages = ("python", "typescript")
+
+    MESSAGE = "Looks like per-connection state held in process memory."
 
     def check(self, project: Project) -> list[Finding]:
+        if project.language == "typescript":
+            return [
+                self.finding(self.MESSAGE, f, line, text)
+                for f, line, text in project.search_code(TS_RX)
+            ]
+
         out: list[Finding] = []
         for f in project.files:
             if f.tree is None:
@@ -55,9 +84,14 @@ class PerConnectionState(Rule):
                     targets = node.targets
                 for target in targets:
                     if isinstance(target, ast.Name) and any(s in target.id for s in SUSPECT):
-                        out.append(self.finding(
-                            f"`{target.id}` looks like per-connection state held in process memory.",
-                            f, node.lineno,
-                            f.lines[node.lineno - 1].strip() if node.lineno <= len(f.lines) else None,
-                        ))
+                        out.append(
+                            self.finding(
+                                f"`{target.id}` looks like per-connection state held in process memory.",
+                                f,
+                                node.lineno,
+                                f.lines[node.lineno - 1].strip()
+                                if node.lineno <= len(f.lines)
+                                else None,
+                            )
+                        )
         return out

--- a/tests/fixtures/fixer_roundtrip/server.py
+++ b/tests/fixtures/fixer_roundtrip/server.py
@@ -35,3 +35,12 @@ async def list_tools() -> list[Tool]:
         Tool(name="zeta", description="Last alphabetically."),
         Tool(name="alpha", description="First alphabetically."),
     ]
+
+# R021: old JSON Schema dialect pin -- the fixer must rewrite this
+TOOL_INPUT_SCHEMA = {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "properties": {
+        "name": {"type": "string"},
+    },
+}

--- a/tests/test_fixers.py
+++ b/tests/test_fixers.py
@@ -303,6 +303,75 @@ def test_r017_idempotent():
 
 
 # ---------------------------------------------------------------------------
+# R021 -- old JSON Schema dialect pin
+# ---------------------------------------------------------------------------
+
+_TARGET_DIALECT = "http://json-schema.org/draft/2020-12/schema"
+
+
+def test_r021_rewrites_draft07_url():
+    before = '"$schema": "http://json-schema.org/draft-07/schema#"\n'
+    result = fix("OldJSONSchemaDialectFixer", before)
+    assert result.changed
+    assert result.text == f'"$schema": "{_TARGET_DIALECT}"\n'
+    assert FIXERS["OldJSONSchemaDialectFixer"].confidence == "safe"
+
+
+def test_r021_rewrites_draft04_url():
+    before = '"$schema": "http://json-schema.org/draft-04/schema"\n'
+    result = fix("OldJSONSchemaDialectFixer", before)
+    assert result.changed
+    assert f'"{_TARGET_DIALECT}"' in result.text
+
+
+def test_r021_rewrites_2019_09_url():
+    before = '"$schema": "http://json-schema.org/draft/2019-09/schema"\n'
+    result = fix("OldJSONSchemaDialectFixer", before)
+    assert result.changed
+    assert f'"{_TARGET_DIALECT}"' in result.text
+
+
+def test_r021_rewrites_short_2019_09():
+    before = '"$schema": "2019-09"\n'
+    result = fix("OldJSONSchemaDialectFixer", before)
+    assert result.changed
+    assert f'"{_TARGET_DIALECT}"' in result.text
+
+
+def test_r021_leaves_ambiguous_comment_alone():
+    """A mention of draft-07 that is NOT inside a $schema assignment must not
+    be touched -- that would be a false positive and silent corruption."""
+    before = "# Previously used draft-07 schema dialect\n"
+    result = fix("OldJSONSchemaDialectFixer", before)
+    assert result.changed is False
+    assert result.text == before
+
+
+def test_r021_leaves_unrelated_key_alone():
+    """An old dialect string in a value keyed by something other than $schema
+    must not be rewritten -- the fixer cannot know what that string means."""
+    before = '"description": "http://json-schema.org/draft-07/schema#"\n'
+    result = fix("OldJSONSchemaDialectFixer", before)
+    assert result.changed is False
+    assert result.text == before
+
+
+def test_r021_idempotent():
+    before = '"$schema": "http://json-schema.org/draft-07/schema#"\n'
+    once = fix("OldJSONSchemaDialectFixer", before)
+    twice = fix("OldJSONSchemaDialectFixer", once.text)
+    assert twice.changed is False
+    assert twice.text == once.text
+
+
+def test_r021_already_2020_12_is_unchanged():
+    before = f'"$schema": "{_TARGET_DIALECT}"\n'
+    result = fix("OldJSONSchemaDialectFixer", before)
+    assert result.changed is False
+    assert result.text == before
+
+
+# ---------------------------------------------------------------------------
 # CLI: fix / fixers
 # ---------------------------------------------------------------------------
 

--- a/tests/test_fixers.py
+++ b/tests/test_fixers.py
@@ -372,6 +372,47 @@ def test_r021_already_2020_12_is_unchanged():
 
 
 # ---------------------------------------------------------------------------
+# R020 -- Dynamic Client Registration deprecated
+# ---------------------------------------------------------------------------
+
+def test_r020_annotates_register_client():
+    before = "def register_client(request):\n    pass\n"
+    result = fix("DynamicClientRegistrationDeprecatedFixer", before)
+    assert result.changed
+    assert "TODO(mcp-migrate): RFC 7591 Dynamic Client Registration is deprecated" in result.text
+    assert FIXERS["DynamicClientRegistrationDeprecatedFixer"].confidence == "review"
+
+
+def test_r020_annotates_register_client_request():
+    before = "req = RegisterClientRequest()\n"
+    result = fix("DynamicClientRegistrationDeprecatedFixer", before)
+    assert result.changed
+    assert "TODO(mcp-migrate)" in result.text
+
+
+def test_r020_annotates_dynamic_client_registration():
+    before = "class DynamicClientRegistration:\n    pass\n"
+    result = fix("DynamicClientRegistrationDeprecatedFixer", before)
+    assert result.changed
+    assert "TODO(mcp-migrate)" in result.text
+
+
+def test_r020_leaves_comments_alone():
+    before = "# Note: register_client was used previously\n"
+    result = fix("DynamicClientRegistrationDeprecatedFixer", before)
+    assert result.changed is False
+    assert result.text == before
+
+
+def test_r020_idempotent():
+    before = "req = RegisterClientRequest()\n"
+    once = fix("DynamicClientRegistrationDeprecatedFixer", before)
+    twice = fix("DynamicClientRegistrationDeprecatedFixer", once.text)
+    assert twice.changed is False
+    assert twice.text == once.text
+
+
+# ---------------------------------------------------------------------------
 # CLI: fix / fixers
 # ---------------------------------------------------------------------------
 

--- a/tests/test_typescript.py
+++ b/tests/test_typescript.py
@@ -21,6 +21,7 @@ from mcp_migrate.cli import main, run_check
 from mcp_migrate.rules import all_rules
 from mcp_migrate.rules.base import Project, SourceFile, _ts_spans
 from mcp_migrate.rules.r001_session_id_removed import SessionIdRemoved
+from mcp_migrate.rules.r002_connection_state import PerConnectionState
 from mcp_migrate.rules.r003_routing_headers import MissingRoutingHeaders
 from mcp_migrate.rules.r004_tool_ordering import NondeterministicToolOrder
 from mcp_migrate.rules.r005_extensions import NoExtensionsDeclared
@@ -85,6 +86,40 @@ def test_r006_finds_sse_in_typescript(tmp_path):
     findings = DeprecatedSSETransport().check(project.for_language("typescript"))
     # The SDK import, the route literal, and the constructor.
     assert len(findings) >= 2
+
+
+def test_r002_finds_module_level_connection_state_in_typescript(tmp_path):
+    code = """\
+const sessions = new Map<string, any>();
+
+export async function handleRequest(req, res) {
+  sessions.set(req.id, req);
+}
+"""
+    project = load_project(_write(tmp_path, "server.ts", code)).for_language("typescript")
+    findings = PerConnectionState().check(project)
+    assert len(findings) == 1
+    assert findings[0].line == 1
+
+
+def test_r002_stays_silent_on_stateless_typescript_server(tmp_path):
+    code = """\
+export async function handleRequest(req, res) {
+  const localCache = new Map();
+  return req;
+}
+"""
+    project = load_project(_write(tmp_path, "server.ts", code)).for_language("typescript")
+    assert PerConnectionState().check(project) == []
+
+
+def test_r002_ignores_connection_state_named_only_in_comment(tmp_path):
+    code = """\
+// const sessions = new Map();
+export const STACK = "mcp";
+"""
+    project = load_project(_write(tmp_path, "server.ts", code)).for_language("typescript")
+    assert PerConnectionState().check(project) == []
 
 
 def test_r015_finds_missing_result_type_in_typescript(tmp_path):


### PR DESCRIPTION
Closes #32

## Summary

Ports rule **R002** (*Keeps per-connection state in a module-level dict*) to TypeScript.

## Implementation Details

- Added `languages = ("python", "typescript")` to `PerConnectionState` in `src/mcp_migrate/rules/r002_connection_state.py`.
- Implemented TypeScript checking branch using `project.search_code(TS_RX)` to search for top-level module/class scope declarations of suspect connection-state stores (`sessions`, `sessionStore`, `session_store`, `_sessions`, `connections`, `sessionState`, `SESSIONS`, `clientState`, `perSession`) initialized with `new Map()`, `new Set()`, `new Object()`, or `{}`.
- Uses `search_code` so comments and string literals in TypeScript files are automatically filtered without false positives.

## Unit Tests

Added 3 unit tests in `tests/test_typescript.py`:
1. `test_r002_finds_module_level_connection_state_in_typescript`: detects `const sessions = new Map<string, any>()`
2. `test_r002_stays_silent_on_stateless_typescript_server`: passes cleanly when state is local to a request handler
3. `test_r002_ignores_connection_state_named_only_in_comment`: ignores mentions in comments

## Verification

- `pytest`: 241 passed (0 failures)
- `ruff check src/mcp_migrate/rules/r002_connection_state.py`: clean (0 issues)