### PR TITLE
fix(r003): add review-confidence fixer for routing headers

### DIFF
--- a/cookbook/14-routing-headers.md
+++ b/cookbook/14-routing-headers.md
@@ -1,7 +1,7 @@
 # Required `Mcp-Method` / `Mcp-Name` routing headers
 
 - **Rule:** [R003](../src/mcp_migrate/rules/r003_routing_headers.py)
-- **Fixer:** none
+- **Fixer:** [`RoutingHeadersFixer`](../src/mcp_migrate/fixers/r003_routing_headers.py) (`review` confidence — adds headers to inline `headers={...}` dicts and leaves TODOs elsewhere)
 - **Severity:** advisory (downgraded from an earlier `breaking` after a real
   false-positive incident -- see the rule source's comment for the
   mcp-atlassian story before reaching for a fixer here)

--- a/src/mcp_migrate/fixers/r003_routing_headers.py
+++ b/src/mcp_migrate/fixers/r003_routing_headers.py
@@ -1,0 +1,259 @@
+"""Fixer for R003 -- Mcp-Method / Mcp-Name routing headers on hand-rolled HTTP.
+
+Hand-rolled MCP wire traffic must carry routing headers so proxies can
+dispatch without parsing the body. There is no single mechanical value for
+every call site (method/name may be dynamic), so this fixer handles only
+the narrowest safe shape -- an inline ``headers={...}`` dict on a
+``.post()``/``.request()`` call -- and leaves a TODO everywhere else.
+Confidence "review": header values still need a human pass.
+"""
+from __future__ import annotations
+
+import ast
+import re
+from pathlib import Path
+
+from mcp_migrate.rules.r003_routing_headers import (
+    HAND_ROLLED_CALL,
+    HTTP_LIBS,
+    MCP_METHOD_RX,
+    NAME_REQUIRED_RX,
+    _imports_mcp,
+)
+
+from ._textedit import find_matching_close, leading_ws
+from .base import Fixer, FixResult
+
+COOKBOOK = "cookbook/14-routing-headers.md"
+SPEC_URL = (
+    "https://modelcontextprotocol.io/specification/2026-07-28/basic/transports/streamable-http"
+)
+TODO = (
+    "# TODO(mcp-migrate): add Mcp-Method"
+    " (and Mcp-Name for tools/call, resources/read, or prompts/get)"
+    f" — see {SPEC_URL} and {COOKBOOK}"
+)
+
+POST_CALL_RX = re.compile(r"\.(?:post|request)\s*\(")
+HEADERS_KW_RX = re.compile(r"\bheaders\s*=\s*\{")
+METHOD_LITERAL_RX = re.compile(r"""["']method["']\s*:\s*["']([^"']+)["']""")
+METHOD_IDENT_RX = re.compile(r"""["']method["']\s*:\s*([A-Za-z_][A-Za-z0-9_]*)""")
+NAME_IDENT_RX = re.compile(r"""["']name["']\s*:\s*([A-Za-z_][A-Za-z0-9_]*)""")
+
+
+def _file_context(source: str):
+    """Return gating flags mirroring the R003 rule's per-file checks."""
+    tree = None
+    try:
+        tree = ast.parse(source)
+    except SyntaxError:
+        pass
+
+    class _F:
+        def __init__(self, text: str, tree):
+            self.text = text
+            self.tree = tree
+            self.lines = text.splitlines()
+
+    f = _F(source, tree)
+    has_http = any(lib in source for lib in HTTP_LIBS)
+    mcp_surface = bool(MCP_METHOD_RX.search(source)) or _imports_mcp(f)
+    requires_name = bool(NAME_REQUIRED_RX.search(source))
+    missing_method = "Mcp-Method" not in source
+    missing_name = requires_name and "Mcp-Name" not in source
+    return has_http, mcp_surface, requires_name, missing_method, missing_name
+
+
+def _method_value(call_span: str) -> str:
+    m = METHOD_LITERAL_RX.search(call_span)
+    if m:
+        return f'"{m.group(1)}"'
+    m = METHOD_IDENT_RX.search(call_span)
+    if m:
+        return m.group(1)
+    return '"<set-mcp-method>"'
+
+
+def _name_value(call_span: str) -> str:
+    m = NAME_IDENT_RX.search(call_span)
+    if m:
+        return m.group(1)
+    return '"<set-mcp-name>"'
+
+
+def _insert_headers_entries(
+    lines: list[str],
+    open_i: int,
+    open_col: int,
+    close_i: int,
+    close_col: int,
+    *,
+    add_method: bool,
+    add_name: bool,
+    method_val: str,
+    name_val: str,
+) -> None:
+    """Insert Mcp-Method / Mcp-Name entries before the closing ``}``."""
+    entries: list[str] = []
+    if add_method:
+        entries.append(f'"Mcp-Method": {method_val}')
+    if add_name:
+        entries.append(f'"Mcp-Name": {name_val}')
+    if not entries:
+        return
+
+    if open_i == close_i:
+        # Single-line headers={...} — splice comma-separated entries before ``}``.
+        line = lines[close_i]
+        inner = line[open_col + 1 : close_col].rstrip()
+        suffix = line[close_col + 1 :]
+        insertion = ", ".join(entries)
+        if inner.strip():
+            new_inner = f"{inner.rstrip()}, {insertion}"
+        else:
+            new_inner = insertion
+        lines[close_i] = line[: open_col + 1] + new_inner + "}" + suffix
+        return
+
+    content_indent = None
+    for k in range(open_i + 1, close_i + 1):
+        if lines[k].strip():
+            content_indent = leading_ws(lines[k])
+            break
+    if content_indent is None:
+        content_indent = leading_ws(lines[open_i]) + "    "
+
+    prev = close_i - 1
+    while prev > open_i and not lines[prev].strip():
+        prev -= 1
+    if prev >= open_i:
+        stripped = lines[prev].rstrip("\n")
+        if stripped.strip() and not stripped.rstrip().endswith(","):
+            nl = "\n" if lines[prev].endswith("\n") else ""
+            lines[prev] = stripped.rstrip() + "," + nl
+
+    insertion_lines = [f"{content_indent}{entry}," for entry in entries]
+    newline = "\n" if lines[close_i].endswith("\n") else ""
+    lines.insert(close_i, "".join(f"{line}{newline}" for line in insertion_lines))
+
+
+def _headers_dict_in_call(lines: list[str], call_i: int, close_i: int):
+    """Locate an inline headers={...} dict inside a .post/.request call."""
+    for line_idx in range(call_i, close_i + 1):
+        hm = HEADERS_KW_RX.search(lines[line_idx])
+        if not hm:
+            continue
+        brace_col = hm.end() - 1
+        h_closed = find_matching_close(lines, line_idx, brace_col)
+        if h_closed is None:
+            continue
+        h_close_i, h_close_col = h_closed
+        headers_span = (
+            "".join(lines[line_idx : h_close_i + 1])
+            if h_close_i > line_idx
+            else lines[line_idx][brace_col : h_close_col + 1]
+        )
+        return line_idx, brace_col, h_close_i, h_close_col, headers_span
+    return None
+
+
+class RoutingHeadersFixer(Fixer):
+    rule_id = "R003"
+    title = "Add Mcp-Method/Mcp-Name to inline headers={} on hand-rolled POSTs, TODO elsewhere"
+    confidence = "review"
+
+    def fix(self, source: str, path: Path) -> FixResult:
+        has_http, mcp_surface, requires_name, missing_method, missing_name = _file_context(source)
+        if not has_http or not mcp_surface:
+            return self.unchanged(source)
+        if not missing_method and not missing_name:
+            return self.unchanged(source)
+
+        lines = source.splitlines(keepends=True)
+        changes: list[str] = []
+        fixed_call_lines: set[int] = set()
+
+        # Pass 1: mechanical insert into inline headers={...} dicts.
+        call_targets: list[tuple[int, int, int, int, str, bool, bool]] = []
+        for i, line in enumerate(lines):
+            m = POST_CALL_RX.search(line)
+            if not m:
+                continue
+            open_col = m.end() - 1
+            closed = find_matching_close(lines, i, open_col)
+            if closed is None:
+                continue
+            close_i, close_col = closed
+            located = _headers_dict_in_call(lines, i, close_i)
+            if located is None:
+                continue
+            h_open_i, h_open_col, h_close_i, h_close_col, headers_span = located
+            if "Mcp-Method" in headers_span and (not requires_name or "Mcp-Name" in headers_span):
+                continue
+
+            add_method = missing_method and "Mcp-Method" not in headers_span
+            add_name = missing_name and requires_name and "Mcp-Name" not in headers_span
+            if not add_method and not add_name:
+                continue
+
+            call_span = "".join(lines[i : close_i + 1])
+            call_targets.append(
+                (h_close_i, h_open_i, h_open_col, h_close_i, h_close_col, call_span, add_method, add_name)
+            )
+            fixed_call_lines.add(i)
+
+        for (
+            _sort_key,
+            h_open_i,
+            h_open_col,
+            h_close_i,
+            h_close_col,
+            call_span,
+            add_method,
+            add_name,
+        ) in sorted(call_targets, key=lambda t: t[0], reverse=True):
+            method_val = _method_value(call_span)
+            name_val = _name_value(call_span)
+            _insert_headers_entries(
+                lines,
+                h_open_i,
+                h_open_col,
+                h_close_i,
+                h_close_col,
+                add_method=add_method,
+                add_name=add_name,
+                method_val=method_val,
+                name_val=name_val,
+            )
+            changes.append(
+                f"line {h_open_i + 1}: added routing headers to inline headers={{...}}"
+            )
+
+        # Pass 2: TODO above hand-rolled calls we could not fix mechanically.
+        out: list[str] = []
+        for i, raw_line in enumerate(lines):
+            if i in fixed_call_lines:
+                out.append(raw_line)
+                continue
+            if not HAND_ROLLED_CALL.search(raw_line):
+                out.append(raw_line)
+                continue
+            stripped = raw_line.lstrip(" \t")
+            if stripped.startswith("#"):
+                out.append(raw_line)
+                continue
+            if raw_line.rstrip("\n").rstrip().endswith(":"):
+                out.append(raw_line)
+                continue
+
+            indent = raw_line[: len(raw_line) - len(stripped)]
+            newline = "\n" if raw_line.endswith("\n") else ""
+            if not (out and out[-1].strip(" \t\n") == TODO):
+                out.append(f"{indent}{TODO}{newline}")
+                changes.append(f"line {i + 1}: added TODO for missing routing headers")
+            out.append(raw_line)
+
+        new_text = "".join(out)
+        if not changes:
+            return self.unchanged(source)
+        return self.result(new_text, changes)

--- a/tests/test_fixers.py
+++ b/tests/test_fixers.py
@@ -39,7 +39,7 @@ def fix(name: str, source: str, path: str = "server.py"):
 # ---------------------------------------------------------------------------
 
 def test_ships_a_fixer_for_every_rule_the_task_calls_out():
-    assert {"R001", "R004", "R005", "R006", "R007", "R014", "R017", "R019"} <= FIXER_RULE_IDS
+    assert {"R001", "R003", "R004", "R005", "R006", "R007", "R014", "R017", "R019"} <= FIXER_RULE_IDS
 
 
 def test_every_fixer_has_a_valid_confidence_and_metadata():
@@ -268,6 +268,141 @@ def test_r006_idempotent():
     )
     once = fix("SseTransportFixer", before)
     twice = fix("SseTransportFixer", once.text)
+    assert twice.changed is False
+    assert twice.text == once.text
+
+
+# ---------------------------------------------------------------------------
+# R003 -- Mcp-Method / Mcp-Name routing headers
+# ---------------------------------------------------------------------------
+
+R003_INLINE_HEADERS_BEFORE = (
+    'import httpx\n'
+    '\n'
+    '_client = httpx.Client()\n'
+    '\n'
+    '\n'
+    'def call_tool(tool_name: str, arguments: dict) -> None:\n'
+    '    _client.post(\n'
+    '        "https://relay.internal/mcp",\n'
+    '        headers={"Content-Type": "application/json"},\n'
+    '        json={"jsonrpc": "2.0", "method": "tools/call", "params": {"name": tool_name, "arguments": arguments}},\n'
+    '    )\n'
+)
+R003_INLINE_HEADERS_AFTER = (
+    'import httpx\n'
+    '\n'
+    '_client = httpx.Client()\n'
+    '\n'
+    '\n'
+    'def call_tool(tool_name: str, arguments: dict) -> None:\n'
+    '    _client.post(\n'
+    '        "https://relay.internal/mcp",\n'
+    '        headers={"Content-Type": "application/json", "Mcp-Method": "tools/call", "Mcp-Name": tool_name},\n'
+    '        json={"jsonrpc": "2.0", "method": "tools/call", "params": {"name": tool_name, "arguments": arguments}},\n'
+    '    )\n'
+)
+
+R003_TODO_BEFORE = (
+    'import httpx\n'
+    '\n'
+    '_client = httpx.Client()\n'
+    '\n'
+    '\n'
+    'def notify(method: str, event: dict) -> None:\n'
+    '    _client.post(\n'
+    '        "https://hooks.internal.example.com/mcp-events",\n'
+    '        json={"jsonrpc": "2.0", "method": method, "params": event},\n'
+    '    )\n'
+)
+
+
+def test_r003_adds_routing_headers_to_inline_headers_dict():
+    result = fix("RoutingHeadersFixer", R003_INLINE_HEADERS_BEFORE)
+    assert result.changed
+    assert result.text == R003_INLINE_HEADERS_AFTER
+    assert FIXERS["RoutingHeadersFixer"].confidence == "review"
+    ast.parse(result.text)
+
+
+def test_r003_leaves_plain_rest_client_alone():
+    before = (
+        'import httpx\n'
+        '\n'
+        'def fetch_issue(issue_id: str):\n'
+        '    return httpx.get(f"https://jira.example.com/rest/api/2/issue/{issue_id}")\n'
+    )
+    result = fix("RoutingHeadersFixer", before)
+    assert result.changed is False
+    assert result.text == before
+
+
+def test_r003_adds_routing_headers_to_multiline_headers_dict():
+    before = (
+        'import httpx\n'
+        '\n'
+        '_client = httpx.Client()\n'
+        '\n'
+        '\n'
+        'def call_tool(tool_name: str, arguments: dict) -> None:\n'
+        '    _client.post(\n'
+        '        "https://relay.internal/mcp",\n'
+        '        headers={\n'
+        '            "Content-Type": "application/json",\n'
+        '        },\n'
+        '        json={"jsonrpc": "2.0", "method": "tools/call", "params": {"name": tool_name, "arguments": arguments}},\n'
+        '    )\n'
+    )
+    after = (
+        'import httpx\n'
+        '\n'
+        '_client = httpx.Client()\n'
+        '\n'
+        '\n'
+        'def call_tool(tool_name: str, arguments: dict) -> None:\n'
+        '    _client.post(\n'
+        '        "https://relay.internal/mcp",\n'
+        '        headers={\n'
+        '            "Content-Type": "application/json",\n'
+        '            "Mcp-Method": "tools/call",\n'
+        '            "Mcp-Name": tool_name,\n'
+        '        },\n'
+        '        json={"jsonrpc": "2.0", "method": "tools/call", "params": {"name": tool_name, "arguments": arguments}},\n'
+        '    )\n'
+    )
+    result = fix("RoutingHeadersFixer", before)
+    assert result.changed
+    assert result.text == after
+    ast.parse(result.text)
+
+
+def test_r003_adds_todo_when_headers_dict_is_not_inline():
+    result = fix("RoutingHeadersFixer", R003_TODO_BEFORE)
+    assert result.changed
+    assert result.text.count("TODO(mcp-migrate): add Mcp-Method") == 1
+    assert result.text.index("TODO(mcp-migrate)") < result.text.index("_client.post(")
+    assert '"Mcp-Method":' not in result.text
+    ast.parse(result.text)
+
+
+def test_r003_refuses_to_guess_on_headers_variable():
+    before = (
+        'import httpx\n'
+        '\n'
+        'def relay(method: str, payload: dict, base_headers: dict) -> None:\n'
+        '    httpx.post("https://relay/mcp", headers=base_headers, json={"method": method, "jsonrpc": "2.0"})\n'
+    )
+    result = fix("RoutingHeadersFixer", before)
+    assert result.changed
+    assert "TODO(mcp-migrate)" in result.text
+    assert "headers=base_headers" in result.text
+    assert '"Mcp-Method":' not in result.text
+    ast.parse(result.text)
+
+
+def test_r003_idempotent():
+    once = fix("RoutingHeadersFixer", R003_INLINE_HEADERS_BEFORE)
+    twice = fix("RoutingHeadersFixer", once.text)
     assert twice.changed is False
     assert twice.text == once.text
 


### PR DESCRIPTION
## What kind of PR is this?

- [x] Fixer -- adds/changes a fixer in `src/mcp_migrate/fixers/`

## Fixer

- [x] `rule_id` matches an existing rule's `id` (R003)
- [x] `confidence` is `review` — header values may be dynamic or need human verification
- [x] Ambiguous shapes are left unchanged — variable `headers=`, missing inline dict get TODO only
- [x] Idempotency test included
- [x] `mcp-migrate fixers` lists the new fixer

## Summary

Adds `RoutingHeadersFixer` for R003 (missing `Mcp-Method` / `Mcp-Name` routing headers on hand-rolled HTTP clients).

## Motivation

Issue #16 requests a conservative autofixer for R003. The rule was downgraded to `advisory` after mcp-atlassian false positives, so the fixer mirrors the same gating and only edits the narrowest mechanical shape.

## Changes

- New `RoutingHeadersFixer` in `src/mcp_migrate/fixers/r003_routing_headers.py`
- Mechanical fix: insert `Mcp-Method` / `Mcp-Name` into inline `headers={...}` dicts on `.post()` / `.request()` calls
- TODO fallback for call sites without an inline headers dict (variable headers, no headers kwarg, etc.)
- Reuses R003 rule constants for gating (`HTTP_LIBS`, `MCP_METHOD_RX`, `NAME_REQUIRED_RX`, `_imports_mcp`)
- Tests: inline + multiline headers, plain REST backoff, TODO-only path, idempotency
- Updated `cookbook/14-routing-headers.md` fixer reference

## Tests

```
pytest tests/test_fixers.py -k r003  # 6 passed
pytest  # 292 passed
```

## Notes

- Method/name values are inferred from nearby `json=` literals/identifiers when possible; otherwise placeholders like `"<set-mcp-method>"` are used (review confidence).
- Does not add a new `headers=` kwarg when one is absent — only TODO.

Fixes #16