### PR TITLE
fix(rules): Add wire_method helper with (?![\w/-]) end boundary to prevent false positives on longer strings (#88)

### DIFF
--- a/src/mcp_migrate/rules/base.py
+++ b/src/mcp_migrate/rules/base.py
@@ -383,3 +383,16 @@ class Rule:
             line=line,
             snippet=snippet,
         )
+
+
+def wire_method(*names: str) -> str:
+    r"""Build a regex pattern for JSON-RPC wire method names bounded by (?![\w/-]).
+
+    Prevents false positives on longer, unrelated strings like 'roots/listeners'
+    or 'tasks/listeners'.
+    """
+    if len(names) == 1:
+        return rf"\b{re.escape(names[0])}(?![\w/-])"
+    joined = "|".join(re.escape(n) for n in names)
+    return rf"\b(?:{joined})(?![\w/-])"
+

--- a/src/mcp_migrate/rules/r007_deprecated_features.py
+++ b/src/mcp_migrate/rules/r007_deprecated_features.py
@@ -1,4 +1,4 @@
-from .base import Finding, Project, Rule
+from .base import Finding, Project, Rule, wire_method
 
 # Every pattern here has to be unambiguously MCP. A bare `create_message`
 # was not: it has no word boundary and no MCP context, so it matched
@@ -13,7 +13,7 @@ from .base import Finding, Project, Rule
 # API -- so the `session.` qualifier keeps every true positive while
 # dropping the collision.
 FEATURES = {
-    r"\broots/list\b|list_roots|RootsCapability": ("Roots", "Use resource URIs instead."),
+    rf"{wire_method('roots/list')}|list_roots|RootsCapability": ("Roots", "Use resource URIs instead."),
     r"sampling/createMessage|SamplingCapability|\bsession\.create_message\b"
     r"|\bCreateMessageRequest\b|\bCreateMessageResult\b": (
         "Sampling", "Sampling is deprecated; plan a migration."),

--- a/src/mcp_migrate/rules/r009_initialize_handshake_removed.py
+++ b/src/mcp_migrate/rules/r009_initialize_handshake_removed.py
@@ -1,6 +1,6 @@
 import re
 
-from .base import Finding, Project, Rule
+from .base import Finding, Project, Rule, wire_method
 
 # `InitializeRequest`, `InitializeResult` and `InitializedNotification` are
 # the MCP SDK's own pydantic model names for the initialize handshake --
@@ -40,7 +40,7 @@ class InitializeHandshakeStillImplemented(Rule):
         # so it always starts inside a STRING token and search_code would
         # silently never find it. Match the literal directly instead, the
         # same way r004_tool_ordering.py matches the literal `tools/list`.
-        for f, line, text in project.search_wire(r"notifications/initialized"):
+        for f, line, text in project.search_wire(wire_method("notifications/initialized")):
             out.append(self.finding(
                 "References the removed notifications/initialized handshake message.",
                 f, line, text,

--- a/src/mcp_migrate/rules/r012_logging_set_level_removed.py
+++ b/src/mcp_migrate/rules/r012_logging_set_level_removed.py
@@ -1,6 +1,6 @@
 import re
 
-from .base import Finding, Project, Rule
+from .base import Finding, Project, Rule, wire_method
 
 # `SetLevelRequest`/`SetLevelRequestParams` are the MCP SDK's own model
 # names for this request -- distinctive, no false-positive risk.
@@ -29,7 +29,7 @@ class LoggingSetLevelRemoved(Rule):
         # identifier -- like notifications/initialized in r009, it can only
         # ever appear inside a STRING token, so search_code would never
         # find it. Scan the raw text for the literal instead.
-        for f, line, text in project.search_wire(r"logging/setLevel"):
+        for f, line, text in project.search_wire(wire_method("logging/setLevel")):
             out.append(self.finding(
                 "References the removed logging/setLevel JSON-RPC method.", f, line, text,
             ))

--- a/src/mcp_migrate/rules/r018_multi_round_trip_replaces_server_initiated.py
+++ b/src/mcp_migrate/rules/r018_multi_round_trip_replaces_server_initiated.py
@@ -1,6 +1,4 @@
-import re
-
-from .base import Finding, Project, Rule
+from .base import Finding, Project, Rule, wire_method
 
 # Code-shaped identifiers -- SDK model/class names or plain Python names,
 # matched with search_code so a docstring/comment mention doesn't count.
@@ -57,7 +55,7 @@ class MultiRoundTripReplacesServerInitiated(Rule):
                     f, line, text,
                 ))
         for pattern, name in FEATURES_LITERAL.items():
-            for f, line, text in project.search_wire(pattern):
+            for f, line, text in project.search_wire(wire_method(pattern)):
                 out.append(self.finding(
                     f"{name} was replaced by Multi Round-Trip Requests (InputRequiredResult "
                     "+ inputResponses).",

--- a/src/mcp_migrate/rules/r019_tasks_polling_replaces_blocking_result.py
+++ b/src/mcp_migrate/rules/r019_tasks_polling_replaces_blocking_result.py
@@ -1,6 +1,6 @@
 import re
 
-from .base import Finding, Project, Rule
+from .base import Finding, Project, Rule, wire_method
 
 # `ListTasksRequest`/`GetTaskPayloadRequest` are the MCP SDK's own model
 # names for the two removed shapes (tasks/list, and the blocking
@@ -31,7 +31,7 @@ class TasksPollingReplacesBlockingResult(Rule):
         # valid bare identifiers -- they can only appear inside a STRING
         # token, so search_code would never find them (see the
         # notifications/initialized note in r009). Raw scan instead.
-        for f, line, text in project.search_wire(r"tasks/list|tasks/result"):
+        for f, line, text in project.search_wire(wire_method("tasks/list", "tasks/result")):
             out.append(self.finding(
                 "References the removed tasks/list or blocking tasks/result JSON-RPC "
                 "method.",

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -130,3 +130,44 @@ def test_cli_entry_command_prints_registry_yaml(capsys):
     assert "name: notes-mcp" in out
     assert "repo: acme/notes-mcp" in out
     assert "grade: A" in out
+
+
+def test_wire_method_bounds_prevent_false_positives_on_longer_strings(tmp_path):
+    r"""Issue #88: Wire method patterns bounded by (?![\w/-]) must stay silent
+    when encountering longer, unrelated string names like roots/listeners or
+    tasks/listeners."""
+    code = (
+        'const r = "roots/listeners";\n'
+        'const t = "notifications/initializedElsewhere";\n'
+        'const m = "logging/setLevelLatency";\n'
+        'const e = "tasks/listeners";\n'
+    )
+    target = tmp_path / "app.py"
+    target.write_text(code, encoding="utf-8")
+    _, _, findings, _, _ = run_check(tmp_path)
+    rule_ids = {f.rule_id for f in findings}
+    assert "R007" not in rule_ids
+    assert "R009" not in rule_ids
+    assert "R012" not in rule_ids
+    assert "R018" not in rule_ids
+    assert "R019" not in rule_ids
+
+
+def test_wire_method_bounds_still_catch_exact_wire_method_names(tmp_path):
+    """Exact wire method strings must still be detected by search_wire."""
+    code = (
+        'const r = "roots/list";\n'
+        'const t = "notifications/initialized";\n'
+        'const m = "logging/setLevel";\n'
+        'const e = "tasks/list";\n'
+    )
+    target = tmp_path / "app.py"
+    target.write_text(code, encoding="utf-8")
+    _, _, findings, _, _ = run_check(tmp_path)
+    rule_ids = {f.rule_id for f in findings}
+    assert "R007" in rule_ids or "R018" in rule_ids
+    assert "R009" in rule_ids
+    assert "R012" in rule_ids
+    assert "R019" in rule_ids
+
+


### PR DESCRIPTION
Closes #88

## Summary

Adds a shared `wire_method(*names: str) -> str` helper function in `src/mcp_migrate/rules/base.py` that builds JSON-RPC wire method regex patterns bounded by `(?![\w/-])`.

## Rationale & Impact

- `search_wire()` keeps ordinary string literals. Previously, method-name patterns with no end boundary matched longer, unrelated strings (e.g. `"roots/listeners"` reported as `roots/list`, or `"tasks/listeners"` reported as `tasks/list`).
- Using `(?![\w/-])` ensures that method names end where they say they end, rejecting trailing word characters or slashes while still matching `"roots/list"` inside JSON-RPC envelopes or assignments.
- Updated wire pattern searches across **R007**, **R009**, **R012**, **R018**, and **R019**.

## Verification

- Added `test_wire_method_bounds_prevent_false_positives_on_longer_strings` and `test_wire_method_bounds_still_catch_exact_wire_method_names` in `tests/test_rules.py`.
- `pytest`: **225/225 passed** (`1.53s`).
- `ruff check`: **0 errors** across all modified files.