### PR TITLE
fix(fixers): derive the comment prefix from the file, not the fixer

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,15 +166,6 @@ explicitly; it's implied when you pass neither flag) -- it prints the exact
 unified diff for every file that would change and writes nothing. Pass
 `--write` to apply it. `--dry-run` and `--write` are mutually exclusive.
 
-> [!WARNING]
-> **Do not run `fix --write` on TypeScript yet.**
-> ([#117](https://github.com/dheerajjha/mcp-migrate/issues/117)) Five fixers
-> emit Python `#` comments regardless of the file they are editing, so on a
-> `.ts` file they write lines that are a syntax error. The file will no
-> longer parse, and the tool reports success on its way out. This affects
-> v0.1.3. `check` is unaffected -- it only reads. On TypeScript, use `fix`
-> without `--write` and apply the diff yourself.
-
 Every change is tagged `safe` or `review` in the diff output:
 
 - **`safe`** -- the fixer is certain the transformation can't change

--- a/src/mcp_migrate/fixers/base.py
+++ b/src/mcp_migrate/fixers/base.py
@@ -23,6 +23,48 @@ from pathlib import Path
 
 CONFIDENCES = ("safe", "review")
 
+# Suffixes whose line comment is `//` rather than `#`.
+#
+# Kept in sync with the C-family entries of `languages.EXTENSIONS` -- and
+# deliberately including the `.mts`/`.cts`/`.mjs`/`.cjs` module variants,
+# which the scanner already reads and which an earlier hardcoded list here
+# missed. A suffix absent from this set falls back to `#`, so the failure
+# mode of forgetting one is a `#` in a C-family file: exactly the bug this
+# module exists to prevent. Add the suffix rather than assuming nobody
+# writes it.
+SLASH_COMMENT_SUFFIXES = frozenset({
+    ".ts", ".tsx", ".mts", ".cts",
+    ".js", ".jsx", ".mjs", ".cjs",
+})
+
+# Every prefix a line could already be commented with, in any language a
+# fixer might touch. Used to decide "have we (or a human) already commented
+# this out?" -- and it has to accept *both* families regardless of the file
+# in hand, because a `#` in a TypeScript file is precisely the corruption
+# being repaired here, and re-commenting it would just deepen the damage.
+COMMENT_PREFIXES = ("#", "//")
+
+
+def comment_prefix(path: Path) -> str:
+    """The line-comment prefix to write into `path`, including its space.
+
+    A fixer that hardcodes `# ` writes a Python comment into TypeScript,
+    where `#` starts nothing at all -- the "fixed" file stops parsing, and
+    the tool reports success on its way out. That is strictly worse than
+    the finding it was repairing: every other failure mode in this project
+    produces a wrong *report*, which a human reads and discards. This one
+    edits their source and leaves it broken.
+
+    So the prefix is derived from the file, once, here -- rather than
+    remembered correctly by each of six fixers independently.
+    """
+    return "// " if path.suffix.lower() in SLASH_COMMENT_SUFFIXES else "# "
+
+
+def is_commented(line: str) -> bool:
+    """True if `line`'s first non-whitespace token opens a line comment."""
+    return line.lstrip(" \t").startswith(COMMENT_PREFIXES)
+
 
 @dataclass
 class FixResult:

--- a/src/mcp_migrate/fixers/r001_session_id.py
+++ b/src/mcp_migrate/fixers/r001_session_id.py
@@ -14,10 +14,10 @@ from __future__ import annotations
 import re
 from pathlib import Path
 
-from .base import Fixer, FixResult
+from .base import Fixer, FixResult, comment_prefix, is_commented
 
 SPEC_URL = "https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2567"
-TODO = "# TODO(mcp-migrate): replaced by an explicit handle argument, see " + SPEC_URL
+TODO = "TODO(mcp-migrate): replaced by an explicit handle argument, see " + SPEC_URL
 
 # Only the actual header read/write plumbing -- not every downstream use of
 # a variable that happens to be named `mcp_session_id`/`session_id` (an
@@ -41,9 +41,12 @@ class SessionIdHeaderFixer(Fixer):
         out: list[str] = []
         changes: list[str] = []
 
+        prefix = comment_prefix(path)
+        todo = f"{prefix}{TODO}"
+
         for i, raw_line in enumerate(lines, start=1):
             stripped = raw_line.lstrip(" \t")
-            already_commented = stripped.startswith("#")
+            already_commented = is_commented(raw_line)
             # Block-openers (if/while/for/def/...) are never touched: commenting
             # one out would leave its suite dangling with no body, which is a
             # syntax error, not just a semantic one. When in doubt, don't fix.
@@ -55,9 +58,9 @@ class SessionIdHeaderFixer(Fixer):
                 body = stripped.rstrip("\n")
                 # Idempotency: if the line right above is already our TODO
                 # (e.g. a previous fixer run), don't insert a second one.
-                if not (out and out[-1].strip(" \t\n") == TODO):
-                    out.append(f"{indent}{TODO}{newline}")
-                out.append(f"{indent}# {body}{newline}")
+                if not (out and out[-1].strip(" \t\n") == todo):
+                    out.append(f"{indent}{todo}{newline}")
+                out.append(f"{indent}{prefix}{body}{newline}")
                 changes.append(f"line {i}: commented out Mcp-Session-Id header access, added TODO")
             else:
                 out.append(raw_line)

--- a/src/mcp_migrate/fixers/r006_sse_transport.py
+++ b/src/mcp_migrate/fixers/r006_sse_transport.py
@@ -23,18 +23,14 @@ import re
 from pathlib import Path
 
 from ._textedit import find_matching_close, leading_ws
-from .base import Fixer, FixResult
+from .base import Fixer, FixResult, comment_prefix, is_commented
 
 SPEC_URL = "https://modelcontextprotocol.io/specification/draft/changelog"
-TODO = "# TODO(mcp-migrate): verify no constructor args were lost moving off SSE, see " + SPEC_URL
+TODO = "TODO(mcp-migrate): verify no constructor args were lost moving off SSE, see " + SPEC_URL
 
 IMPORT_RX = re.compile(r"from\s+mcp\.server\.sse\s+import\s+SseServerTransport\b")
 CTOR_RX = re.compile(r"\bSseServerTransport\s*(\()")
 TRANSPORT_KW_RX = re.compile(r'transport\s*=\s*(["\'])sse\1')
-
-
-def _is_commented(line: str) -> bool:
-    return line.lstrip().startswith("#")
 
 
 class SseTransportFixer(Fixer):
@@ -45,10 +41,11 @@ class SseTransportFixer(Fixer):
     def fix(self, source: str, path: Path) -> FixResult:
         lines = source.splitlines(keepends=True)
         changes: list[str] = []
+        todo = f"{comment_prefix(path)}{TODO}"
 
         # 1. Import rename -- single-line, in place.
         for i, line in enumerate(lines):
-            if _is_commented(line):
+            if is_commented(line):
                 continue
             new_line, n = IMPORT_RX.subn(
                 "from mcp.server.streamable_http import StreamableHTTPServerTransport",
@@ -66,7 +63,7 @@ class SseTransportFixer(Fixer):
         # rewritten first.
         targets = []
         for i, line in enumerate(lines):
-            if _is_commented(line):
+            if is_commented(line):
                 continue
             m = CTOR_RX.search(line)
             if not m:
@@ -87,14 +84,14 @@ class SseTransportFixer(Fixer):
                 for k in range(open_i + 1, close_i + 1):
                     lines[k] = ""
             lines[open_i] = new_line
-            lines.insert(open_i, f"{indent}{TODO}\n")
+            lines.insert(open_i, f"{indent}{todo}\n")
             changes.append(
                 f"line {open_i + 1}: SseServerTransport(...) -> StreamableHTTPServerTransport(), flagged for review"
             )
 
         # 3. transport="sse" keyword rename -- single-line, in place.
         for i, line in enumerate(lines):
-            if _is_commented(line):
+            if is_commented(line):
                 continue
             new_line, n = TRANSPORT_KW_RX.subn(
                 lambda mm: f'transport={mm.group(1)}streamable-http{mm.group(1)}', line,

--- a/src/mcp_migrate/fixers/r007_deprecated_features.py
+++ b/src/mcp_migrate/fixers/r007_deprecated_features.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 import re
 from pathlib import Path
 
-from .base import Fixer, FixResult
+from .base import Fixer, FixResult, comment_prefix, is_commented
 
 SPEC_URL = "https://modelcontextprotocol.io/specification/draft/changelog"
 COOKBOOK = "cookbook/18-roots-sampling-logging-deprecated.md"
@@ -28,9 +28,9 @@ FEATURES: dict[str, str] = {
 FEATURE_RX = tuple((re.compile(p), name) for p, name in FEATURES.items())
 
 
-def _todo(feature: str) -> str:
+def _todo(feature: str, prefix: str) -> str:
     return (
-        f"# TODO(mcp-migrate): {feature} is deprecated as a core capability; "
+        f"{prefix}TODO(mcp-migrate): {feature} is deprecated as a core capability; "
         f"see {SPEC_URL} and {COOKBOOK}"
     )
 
@@ -62,21 +62,23 @@ class DeprecatedCoreFeaturesFixer(Fixer):
         out: list[str] = []
         changes: list[str] = []
 
+        prefix = comment_prefix(path)
+
         for i, raw_line in enumerate(lines, start=1):
             stripped = raw_line.lstrip(" \t")
-            already_commented = stripped.startswith("#")
+            already_commented = is_commented(raw_line)
             feature = None if already_commented else _feature_on_line(raw_line)
 
             if feature:
                 indent = raw_line[: len(raw_line) - len(stripped)]
                 newline = "\n" if raw_line.endswith("\n") else ""
-                todo = _todo(feature)
+                todo = _todo(feature, prefix)
                 body = stripped.rstrip("\n")
 
                 if not (out and out[-1].strip(" \t\n") == todo):
                     out.append(f"{indent}{todo}{newline}")
                 if _safe_to_comment_out(raw_line):
-                    out.append(f"{indent}# {body}{newline}")
+                    out.append(f"{indent}{prefix}{body}{newline}")
                     changes.append(
                         f"line {i}: commented out deprecated {feature} usage, added TODO"
                     )

--- a/src/mcp_migrate/fixers/r014_sse_resumability.py
+++ b/src/mcp_migrate/fixers/r014_sse_resumability.py
@@ -13,12 +13,12 @@ from __future__ import annotations
 import re
 from pathlib import Path
 
-from .base import Fixer, FixResult
+from .base import Fixer, FixResult, comment_prefix, is_commented
 
 SPEC_URL = "https://modelcontextprotocol.io/specification/2026-07-28/changelog"
 COOKBOOK = "cookbook/08-sse-resumability-removed.md"
 TODO = (
-    "# TODO(mcp-migrate): SSE resumability via Last-Event-ID is removed; "
+    "TODO(mcp-migrate): SSE resumability via Last-Event-ID is removed; "
     f"see {SPEC_URL} and {COOKBOOK}"
 )
 
@@ -60,9 +60,12 @@ class SseResumabilityFixer(Fixer):
         out: list[str] = []
         changes: list[str] = []
 
+        prefix = comment_prefix(path)
+        todo = f"{prefix}{TODO}"
+
         for i, raw_line in enumerate(lines, start=1):
             stripped = raw_line.lstrip(" \t")
-            already_commented = stripped.startswith("#")
+            already_commented = is_commented(raw_line)
             ends_as_block_opener = raw_line.rstrip("\n").rstrip().endswith(":")
             hit = (
                 None
@@ -76,11 +79,11 @@ class SseResumabilityFixer(Fixer):
                 body = stripped.rstrip("\n")
                 todo_added = False
 
-                if not (out and out[-1].strip(" \t\n") == TODO):
-                    out.append(f"{indent}{TODO}{newline}")
+                if not (out and out[-1].strip(" \t\n") == todo):
+                    out.append(f"{indent}{todo}{newline}")
                     todo_added = True
                 if _safe_to_comment_out(raw_line):
-                    out.append(f"{indent}# {body}{newline}")
+                    out.append(f"{indent}{prefix}{body}{newline}")
                     changes.append(f"line {i}: commented out {hit}, added TODO")
                 elif todo_added:
                     out.append(raw_line)

--- a/src/mcp_migrate/fixers/r019_tasks_polling.py
+++ b/src/mcp_migrate/fixers/r019_tasks_polling.py
@@ -13,12 +13,12 @@ from __future__ import annotations
 import re
 from pathlib import Path
 
-from .base import Fixer, FixResult
+from .base import Fixer, FixResult, comment_prefix, is_commented
 
 SPEC_URL = "https://modelcontextprotocol.io/specification/2026-07-28/changelog"
 COOKBOOK = "cookbook/11-tasks-polling.md"
 TODO = (
-    "# TODO(mcp-migrate): tasks/list and blocking tasks/result are removed; "
+    "TODO(mcp-migrate): tasks/list and blocking tasks/result are removed; "
     f"poll with tasks/get + tasks/update and declare io.modelcontextprotocol/tasks "
     f"under extensions — see {SPEC_URL} and {COOKBOOK}"
 )
@@ -55,9 +55,12 @@ class TasksPollingFixer(Fixer):
         out: list[str] = []
         changes: list[str] = []
 
+        prefix = comment_prefix(path)
+        todo = f"{prefix}{TODO}"
+
         for i, raw_line in enumerate(lines, start=1):
             stripped = raw_line.lstrip(" \t")
-            already_commented = stripped.startswith("#")
+            already_commented = is_commented(raw_line)
             ends_as_block_opener = raw_line.rstrip("\n").rstrip().endswith(":")
             hit = (
                 None
@@ -71,11 +74,11 @@ class TasksPollingFixer(Fixer):
                 body = stripped.rstrip("\n")
                 todo_added = False
 
-                if not (out and out[-1].strip(" \t\n") == TODO):
-                    out.append(f"{indent}{TODO}{newline}")
+                if not (out and out[-1].strip(" \t\n") == todo):
+                    out.append(f"{indent}{todo}{newline}")
                     todo_added = True
                 if _safe_to_comment_out(raw_line):
-                    out.append(f"{indent}# {body}{newline}")
+                    out.append(f"{indent}{prefix}{body}{newline}")
                     changes.append(f"line {i}: commented out {hit}, added TODO")
                 elif todo_added:
                     out.append(raw_line)

--- a/src/mcp_migrate/fixers/r020_dynamic_client_registration_deprecated.py
+++ b/src/mcp_migrate/fixers/r020_dynamic_client_registration_deprecated.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 import re
 from pathlib import Path
 
-from .base import Fixer, FixResult
+from .base import Fixer, FixResult, comment_prefix, is_commented
 
 TODO = (
     "TODO(mcp-migrate): RFC 7591 Dynamic Client Registration is deprecated in "
@@ -43,7 +43,7 @@ class DynamicClientRegistrationDeprecatedFixer(Fixer):
 
         for i, raw_line in enumerate(lines, start=1):
             stripped = raw_line.lstrip(" \t")
-            already_commented = stripped.startswith(("#", "//"))
+            already_commented = is_commented(raw_line)
 
             if (
                 not already_commented
@@ -53,8 +53,7 @@ class DynamicClientRegistrationDeprecatedFixer(Fixer):
             ):
                 indent = raw_line[: len(raw_line) - len(stripped)]
                 newline = "\n" if raw_line.endswith("\n") else ""
-                comment_prefix = "// " if path.suffix in (".ts", ".js", ".tsx", ".jsx") else "# "
-                out.append(f"{indent}{comment_prefix}{TODO}{newline}")
+                out.append(f"{indent}{comment_prefix(path)}{TODO}{newline}")
                 changes.append(f"line {i}: annotated deprecated DCR usage with TODO")
 
             out.append(raw_line)

--- a/tests/test_fixers.py
+++ b/tests/test_fixers.py
@@ -781,3 +781,119 @@ def test_fix_write_then_check_improves_the_grade(roundtrip_copy, capsys):
     # And overall (not just the rules we fix), the project has strictly
     # fewer findings after the fix than before.
     assert len(findings_after) < len(findings_before)
+
+
+# --- comment syntax follows the file, not the fixer (#117) ---------------
+#
+# `#` does not open a comment in TypeScript. A fixer that hardcodes it
+# writes a syntax error into the user's source and then reports success --
+# strictly worse than the finding it was repairing, because every other
+# failure mode in this project produces a wrong *report* a human reads and
+# discards, while this one edits their code and leaves it broken.
+
+TS_SUFFIXES = (".ts", ".tsx", ".mts", ".cts", ".js", ".jsx", ".mjs", ".cjs")
+
+# One source per comment-emitting fixer, shaped to trip it. Written in
+# TypeScript syntax, since that is the language whose comments differ.
+TS_TRIGGERS = {
+    "R001": 'const sessionId = req.headers["Mcp-Session-Id"];\n',
+    "R006": 'const transport = "sse";\n',
+    "R007": 'const roots = await session.create_message(params);\n',
+    "R014": 'const lastEventId = req.headers["Last-Event-ID"];\n',
+    "R019": 'const m = "tasks/list";\n',
+    "R020": 'export async function registerClient(url, metadata) { return fetch(url); }\n',
+}
+
+
+def test_no_fixer_writes_a_python_comment_into_typescript():
+    # The regression guard for #117, across every fixer at once: a new
+    # fixer that hardcodes `# ` fails here without anyone remembering to
+    # add it to a list.
+    for fixer in all_fixers():
+        source = TS_TRIGGERS.get(fixer.rule_id)
+        if source is None:
+            continue
+        result = fixer.fix(source, Path("server.ts"))
+        if not result.changed:
+            continue
+        added = [
+            line for line in result.text.splitlines()
+            if line.lstrip().startswith("#")
+        ]
+        assert not added, (
+            f"{type(fixer).__name__} wrote a Python `#` comment into a .ts "
+            f"file, which does not parse: {added}"
+        )
+
+
+def test_typescript_fixes_use_slash_comments():
+    from mcp_migrate.fixers.r001_session_id import SessionIdHeaderFixer
+
+    source = 'const sessionId = req.headers["Mcp-Session-Id"];\n'
+    result = SessionIdHeaderFixer().fix(source, Path("server.ts"))
+
+    assert result.changed
+    assert "// TODO(mcp-migrate)" in result.text
+    assert '// const sessionId' in result.text
+    assert "#" not in result.text
+
+
+def test_python_fixes_still_use_hash_comments():
+    from mcp_migrate.fixers.r001_session_id import SessionIdHeaderFixer
+
+    source = 'session_id = request.headers.get("Mcp-Session-Id")\n'
+    result = SessionIdHeaderFixer().fix(source, Path("server.py"))
+
+    assert result.changed
+    assert "# TODO(mcp-migrate)" in result.text
+    # Checked per line, not as a substring: the TODO carries a spec URL,
+    # and `https://` contains a `//` that is not a comment marker.
+    assert not [ln for ln in result.text.splitlines() if ln.lstrip().startswith("//")]
+
+
+@pytest.mark.parametrize("suffix", TS_SUFFIXES)
+def test_every_c_family_suffix_gets_slash_comments(suffix):
+    # .mts/.cts/.mjs/.cjs are read by the scanner and were missing from the
+    # one hardcoded suffix list that did exist, so they corrupted silently.
+    from mcp_migrate.fixers.base import comment_prefix
+
+    assert comment_prefix(Path(f"server{suffix}")) == "// "
+
+
+def test_unknown_suffix_falls_back_to_hash():
+    from mcp_migrate.fixers.base import comment_prefix
+
+    assert comment_prefix(Path("server.py")) == "# "
+    assert comment_prefix(Path("Makefile")) == "# "
+
+
+def test_typescript_fix_output_has_no_stray_hash_lines():
+    # End-to-end on the issue's own repro: the whole point is that the
+    # file still parses as TypeScript afterwards.
+    from mcp_migrate.fixers.r001_session_id import SessionIdHeaderFixer
+    from mcp_migrate.fixers.r019_tasks_polling import TasksPollingFixer
+
+    source = (
+        "export function register(server: Server) {\n"
+        '  const sessionId = req.headers["Mcp-Session-Id"];\n'
+        '  const m = "tasks/list";\n'
+        "  return { sessionId, m };\n"
+        "}\n"
+    )
+    text = SessionIdHeaderFixer().fix(source, Path("server.ts")).text
+    text = TasksPollingFixer().fix(text, Path("server.ts")).text
+
+    assert not [ln for ln in text.splitlines() if ln.lstrip().startswith("#")]
+    assert text.count("// TODO(mcp-migrate)") == 2
+
+
+def test_typescript_fixes_stay_idempotent():
+    # The `already_commented` check has to recognise `//`, or a second run
+    # comments the comment.
+    from mcp_migrate.fixers.r001_session_id import SessionIdHeaderFixer
+
+    fixer = SessionIdHeaderFixer()
+    once = fixer.fix('const s = req.headers["Mcp-Session-Id"];\n', Path("server.ts")).text
+    twice = fixer.fix(once, Path("server.ts"))
+
+    assert not twice.changed, "second run must be a no-op"


### PR DESCRIPTION
Fixes #117.

`fix --write` wrote Python `#` comments into TypeScript, where `#` opens nothing at all. The "fixed" file stopped parsing, and the tool printed `Changes written.` on its way out.

That asymmetry is why this one seemed worth doing carefully rather than patching five string literals: every other known issue in this repo produces a wrong **report**, which a human reads and discards. This one edits their source and leaves it broken.

## The fix

The prefix is derived once, from the path, in `fixers/base.py`:

```python
comment_prefix(Path("server.ts"))  # -> "// "
comment_prefix(Path("server.py"))  # -> "# "
```

…rather than remembered correctly by each of six fixers independently.

| Fixer | Before | After |
|---|---|---|
| `r001_session_id` | hardcoded `# ` | `comment_prefix(path)` |
| `r006_sse_transport` | hardcoded `# ` | `comment_prefix(path)` |
| `r007_deprecated_features` | hardcoded `# ` | `comment_prefix(path)` |
| `r014_sse_resumability` | hardcoded `# ` | `comment_prefix(path)` |
| `r019_tasks_polling` | hardcoded `# ` | `comment_prefix(path)` |
| `r020_dynamic_client_registration` | correct, own inline list | shared helper |

R020 already got this right after #103, but with its own inline suffix list. I moved it onto the shared helper as well — one place to be wrong beats two places that have to stay in agreement.

## Two bugs that fell out of centralising

**Missing module suffixes.** R020's inline list was `(".ts", ".js", ".tsx", ".jsx")`. The scanner also reads `.mts`, `.cts`, `.mjs` and `.cjs` (`languages.EXTENSIONS`), so those were corrupting silently even in the one fixer thought to be correct.

**Idempotency on TypeScript.** `already_commented` only recognised `#`. On a `.ts` file, the `//` written by the first run didn't read as commented, so a second run commented the comment. There's a test pinning that now.

An unknown suffix still falls back to `# `, so forgetting to add one degrades to today's behaviour rather than to something new.

## Verification

The issue's exact repro, on this branch:

```ts
export function register(server: Server) {
  // TODO(mcp-migrate): replaced by an explicit handle argument, see https://github.com/...
  // const sessionId = req.headers["Mcp-Session-Id"];
  // TODO(mcp-migrate): tasks/list and blocking tasks/result are removed; poll with tasks/get...
  // const m = "tasks/list";
  return { sessionId, m };
}
```

Valid TypeScript.

## Tests

The one worth looking at is `test_no_fixer_writes_a_python_comment_into_typescript`: it walks **every** fixer from `all_fixers()`, runs it over a TypeScript trigger, and asserts nothing emits a `#` line. A newly-contributed fixer that hardcodes `# ` fails there without anyone remembering to add it to a list — which matters, since this bug reached five fixers precisely because each was written in isolation.

Plus: per-language prefix assertions, all eight C-family suffixes parametrised, the unknown-suffix fallback, TypeScript idempotency, and the repro end to end.

Full suite: **331 passed**.

Also drops the `README` warning added by #117, since it no longer applies. Happy to split that into its own commit if you'd rather it landed separately.