### PR TITLE
fix(cli): let a breaking finding fail the build on partially-covered languages

### DIFF
--- a/src/mcp_migrate/cli.py
+++ b/src/mcp_migrate/cli.py
@@ -114,6 +114,26 @@ def _print_language_hint(console, counts) -> None:
         )
 
 
+def _exit_for(findings, rules) -> int:
+    """Exit code from findings alone: 1 if anything breaking, else 0."""
+    return EXIT_FINDINGS if any(
+        rules[f.rule_id].severity == "breaking" for f in findings
+    ) else EXIT_OK
+
+
+def _checked_something(project) -> bool:
+    """Did we actually read source, or is this an empty/unreadable tree?
+
+    The discriminator between "partial coverage" and "could not check".
+    A TypeScript project is `PARTIAL` -- we withhold the *grade*, which is
+    correct and deliberate, but we did open files and run rules against
+    them, so the exit code has real information to carry. An empty
+    directory or a tree in a language with no backend read nothing, and
+    EXIT_UNSCANNABLE is the honest answer there.
+    """
+    return bool(project.files)
+
+
 def cmd_check(args) -> int:
     console = Console()
     root = Path(args.path).resolve()
@@ -169,7 +189,8 @@ def cmd_check(args) -> int:
                     "location": f.location(),
                 } for f in findings],
             }, indent=2))
-            return EXIT_UNSCANNABLE
+            return _exit_for(findings, rules) if _checked_something(project) \
+                else EXIT_UNSCANNABLE
         print(json.dumps({
             "spec": SPEC,
             "path": str(root),
@@ -185,9 +206,7 @@ def cmd_check(args) -> int:
                 "location": f.location(),
             } for f in findings],
         }, indent=2))
-        return EXIT_FINDINGS if any(
-            rules[f.rule_id].severity == "breaking" for f in findings
-        ) else EXIT_OK
+        return _exit_for(findings, rules)
 
     console.print()
     console.print(f"[bold]mcp-migrate[/bold] [dim]v{__version__}[/dim]  ->  {root.name}")
@@ -235,7 +254,14 @@ def cmd_check(args) -> int:
         console.print()
         # Not .capitalize() -- that lowercases the rest, turning "24
         # TypeScript" into "24 typescript".
-        headline = "No grade for this one." if findings else "Nothing scannable here."
+        # "Nothing scannable" is only true when we opened nothing. A clean
+        # TypeScript tree now exits 0, and pairing that with "nothing
+        # scannable" would contradict it -- we did read those files and run
+        # every rule that covers them; what we withheld is the grade.
+        headline = (
+            "Nothing scannable here." if not _checked_something(project)
+            else "No grade for this one."
+        )
         console.print(
             f"[bold yellow]{headline}[/bold yellow] {reason[0].upper()}{reason[1:]}."
         )
@@ -258,7 +284,8 @@ def cmd_check(args) -> int:
             "not read.[/dim]"
         )
         console.print()
-        return EXIT_UNSCANNABLE
+        return _exit_for(findings, rules) if _checked_something(project) \
+            else EXIT_UNSCANNABLE
 
     n_python = sum(1 for f in project.files if f.language == "python")
     console.print(f"[dim]{n_python} Python files, {len(rules)} rules, spec {SPEC}[/dim]")

--- a/tests/test_typescript.py
+++ b/tests/test_typescript.py
@@ -1268,7 +1268,9 @@ def test_typescript_only_tree_reports_findings_without_a_grade(tmp_path, capsys)
     exit_code = main(["check", str(_write(tmp_path, "transport.ts", LEGACY_TS)), "--json"])
     data = json.loads(capsys.readouterr().out)
 
-    assert exit_code == 2
+    # 1, not 2: R001 is `breaking`, and a breaking finding has to be able
+    # to fail a build even where the grade is withheld (#98).
+    assert exit_code == 1
     assert data["scannable"] is False
     assert data["grade"] is None
     assert data["score"] is None
@@ -1472,3 +1474,59 @@ def test_production_typescript_that_merely_contains_test_in_the_name_is_kept(tmp
     (tmp_path / "latest.ts").write_text(LEGACY_TS)
     names = sorted(f.path.name for f in load_project(tmp_path).files)
     assert names == ["latest.ts", "testUtils.ts"]
+
+
+# --- exit codes on a partially-covered language (#98) --------------------
+#
+# Withholding the *grade* on partial coverage is deliberate and stays.
+# But findings are findings whether or not we'll stand behind a letter,
+# and before this the ungraded branch returned EXIT_UNSCANNABLE
+# unconditionally -- so a TypeScript server with a real `breaking`
+# finding was indistinguishable, to a shell, from a typo'd path. Most MCP
+# servers are TypeScript, so no TypeScript user could fail a build on a
+# breaking change.
+
+def test_typescript_with_a_breaking_finding_exits_one(tmp_path, capsys):
+    exit_code = main(["check", str(_write(tmp_path, "transport.ts", LEGACY_TS))])
+    capsys.readouterr()
+    assert exit_code == 1, "a breaking finding must fail a build"
+
+
+def test_clean_typescript_exits_zero(tmp_path, capsys):
+    exit_code = main(["check", str(_write(tmp_path, "transport.ts", CLEAN_TS))])
+    capsys.readouterr()
+    assert exit_code == 0
+
+
+def test_an_empty_tree_still_exits_unscannable(tmp_path, capsys):
+    # Nothing was read, so there is nothing to report -- 2 stays 2 here.
+    exit_code = main(["check", str(tmp_path)])
+    capsys.readouterr()
+    assert exit_code == 2
+
+
+def test_a_language_with_no_backend_still_exits_unscannable(tmp_path, capsys):
+    (tmp_path / "main.go").write_text("package main\n")
+    exit_code = main(["check", str(tmp_path)])
+    capsys.readouterr()
+    assert exit_code == 2
+
+
+def test_the_grade_is_still_withheld_for_typescript(tmp_path, capsys):
+    # The exit code changing must not be read as the grade changing.
+    main(["check", str(_write(tmp_path, "transport.ts", LEGACY_TS)), "--json"])
+    data = json.loads(capsys.readouterr().out)
+    assert data["scannable"] is False
+    assert data["grade"] is None
+    assert data["score"] is None
+
+
+def test_json_and_console_exit_codes_agree(tmp_path, capsys):
+    # Two return paths, one contract. They drifted apart once already.
+    for source in (LEGACY_TS, CLEAN_TS):
+        root = _write(tmp_path, "transport.ts", source)
+        console = main(["check", str(root)])
+        capsys.readouterr()
+        as_json = main(["check", str(root), "--json"])
+        capsys.readouterr()
+        assert console == as_json, f"exit codes disagree for {source[:20]!r}"

--- a/tests/test_unscannable.py
+++ b/tests/test_unscannable.py
@@ -67,16 +67,28 @@ def python_tree(tmp_path: Path) -> Path:
 
 # --- check refuses ------------------------------------------------------
 
-@pytest.mark.parametrize("fixture", ["empty_tree", "ts_tree"])
-def test_check_refuses_and_offers_no_grade(fixture, request, capsys):
+# The exit code differs between these two and the grade does not: an empty
+# tree was never read (2, "could not check"), while a clean TypeScript tree
+# was read by every rule that covers it and simply cannot carry a letter
+# (0, nothing breaking found). Withholding the grade is the same decision
+# in both cases; the exit code is not. See #98.
+@pytest.mark.parametrize("fixture,expected_exit", [
+    ("empty_tree", 2),
+    ("ts_tree", 0),
+])
+def test_check_offers_no_grade(fixture, expected_exit, request, capsys):
     root = request.getfixturevalue(fixture)
     exit_code = main(["check", str(root)])
     out = capsys.readouterr().out
 
-    assert exit_code == 2, "an unreadable tree is neither a pass (0) nor findings (1)"
-    assert "Nothing scannable" in out
-    assert "Grade" not in out, f"refused to scan but still emitted a grade: {out}"
-    assert "img.shields.io" not in out, "refused to scan but still offered a badge"
+    assert exit_code == expected_exit
+    assert "Grade" not in out, f"refused to grade but still emitted a grade: {out}"
+    assert "img.shields.io" not in out, "refused to grade but still offered a badge"
+
+
+def test_an_empty_tree_says_nothing_was_scannable(empty_tree, capsys):
+    main(["check", str(empty_tree)])
+    assert "Nothing scannable" in capsys.readouterr().out
 
 
 def test_check_names_the_language_it_found_but_cannot_read(ts_tree, capsys):
@@ -85,13 +97,16 @@ def test_check_names_the_language_it_found_but_cannot_read(ts_tree, capsys):
     assert "TypeScript" in out, "should say what it found, not just that it gave up"
 
 
-@pytest.mark.parametrize("fixture", ["empty_tree", "ts_tree"])
-def test_check_json_reports_no_grade(fixture, request, capsys):
+@pytest.mark.parametrize("fixture,expected_exit", [
+    ("empty_tree", 2),
+    ("ts_tree", 0),
+])
+def test_check_json_reports_no_grade(fixture, expected_exit, request, capsys):
     root = request.getfixturevalue(fixture)
     exit_code = main(["check", str(root), "--json"])
     data = json.loads(capsys.readouterr().out)
 
-    assert exit_code == 2
+    assert exit_code == expected_exit
     assert data["scannable"] is False
     assert data["grade"] is None, "a null grade is the only honest machine answer here"
     assert data["score"] is None


### PR DESCRIPTION
Fixes #98.

The ungraded branch returned `EXIT_UNSCANNABLE` unconditionally, so a TypeScript server with a real `breaking` finding was indistinguishable — to a shell, to CI, to anything — from a typo'd path.

| Project | Documented | Before | After |
|---|---|---|---|
| TypeScript, clean | 0 | 2 ✗ | **0** ✓ |
| TypeScript, breaking | 1 | 2 ✗ | **1** ✓ |
| Empty directory | 2 | 2 ✓ | 2 ✓ |
| Language with no backend | 2 | 2 ✓ | 2 ✓ |
| Path does not exist | 2 | 2 ✓ | 2 ✓ |

## What changed, and what deliberately didn't

Grading and checking were one answer doing two jobs.

**The grade is still withheld.** `grade: null`, `score: null`, `scannable: false`, the on-screen explanation — all unchanged, with a test pinning it. That decision is well-argued and this PR doesn't touch it.

**The exit code now carries findings.** They're findings whether or not we'll stand behind a letter.

The discriminator is `project.files` — did we open anything?

```python
def _checked_something(project) -> bool:
    return bool(project.files)
```

A TypeScript tree is `PARTIAL`, but we *did* read those files and run every rule that covers them. An empty directory or a language with no backend read nothing, and 2 remains the honest answer there.

## The open question in the issue

You asked whether a clean-but-ungraded project should exit 0, and said you held it loosely.

I've taken your lean, for the reason you gave: 0 means "nothing breaking was found", which is exactly what happened, and the printed caveat does the honest work of saying only 16 of 21 rules ran. The counter-argument — that 0 reads as "verified clean" — is real, but it applies equally to a Python project where a rule simply has no pattern for some construct, and we don't hedge the exit code there.

It's one branch in `_checked_something`, so flipping it to `EXIT_UNSCANNABLE`-when-clean is a one-line change if you decide the other way.

## One knock-on

The console printed `Nothing scannable here.` whenever there were no findings. Paired with exit 0 on a clean TypeScript tree, that's self-contradictory — we read those files. It now says that only when nothing was actually opened.

## About the three changed tests

`test_check_refuses_and_offers_no_grade`, `test_check_json_reports_no_grade` and `test_typescript_only_tree_reports_findings_without_a_grade` asserted the old exit code. They're **updated, not deleted** — every no-grade and no-badge assertion is intact, since that half is deliberately unchanged. What changed is that the exit code is now parametrised across the two cases, because an empty tree and a clean TypeScript tree differ in exactly that one respect and agree on everything else.

Flagging it explicitly since "PR changes existing tests" is worth a second look on principle.

## New tests

Breaking TS exits 1 · clean TS exits 0 · empty tree still 2 · no-backend language still 2 · the grade is still withheld · and the JSON and console paths agree, since they're two returns of one contract and they drifted apart once already.

Full suite: **324 passed**.

---

This also unblocks the exit-code half of #85 (`--format json`) — parseable output isn't much use while the exit code says nothing was checked.