### PR TITLE
fix(r014): match TypeScript lastEventId case variants (#143)

### DIFF
--- a/src/mcp_migrate/rules/r014_sse_resumability_removed.py
+++ b/src/mcp_migrate/rules/r014_sse_resumability_removed.py
@@ -1,3 +1,5 @@
+import re
+
 from .base import Finding, Project, Rule
 
 PY_RX = r"Last-Event-ID|last_event_id|LAST_EVENT_ID"
@@ -7,7 +9,15 @@ PY_RX = r"Last-Event-ID|last_event_id|LAST_EVENT_ID"
 # valid identifier in either language -- it can only appear as a string
 # literal -- so that half needs search_wire, kept separate from the
 # identifier half the same way R001 splits header-string vs. identifier.
-TS_CODE_RX = r"\blastEventId\b|\bLastEventId\b"
+#
+# Matched case-insensitively (see TS_CODE_FLAGS): real servers write every
+# casing of the same identifier -- `lastEventId`, `lastEventID`,
+# `LastEventId` -- and a const carrying the header name is usually
+# `LAST_EVENT_ID`, so the optional underscores cover the SCREAMING_SNAKE
+# form too. The `\b` anchors keep it bounded: `lastEventIdentifier` and
+# `lastEventIds` are left alone, which is the conservative direction.
+TS_CODE_RX = r"\blast_?event_?id\b"
+TS_CODE_FLAGS = re.IGNORECASE
 TS_HEADER_RX = r"""["'`]last-event-id["'`]|["'`]Last-Event-ID["'`]"""
 
 MESSAGE = "Implements SSE resumability (Last-Event-ID) -- removed from the transport."
@@ -44,11 +54,14 @@ class SSEResumabilityRemoved(Rule):
     def _check_ts(self, project: Project) -> list[Finding]:
         seen: set[tuple[str, int]] = set()
         out: list[Finding] = []
-        for pattern, search in (
-            (TS_CODE_RX, project.search_code),
-            (TS_HEADER_RX, project.search_wire),
+        # The header half stays case-sensitive on purpose: it matches a
+        # quoted string, and both spellings servers actually send are
+        # already listed in TS_HEADER_RX.
+        for pattern, search, flags in (
+            (TS_CODE_RX, project.search_code, TS_CODE_FLAGS),
+            (TS_HEADER_RX, project.search_wire, 0),
         ):
-            for f, line, text in search(pattern):
+            for f, line, text in search(pattern, flags=flags):
                 key = (str(f.path), line)
                 if key in seen:
                     continue

--- a/tests/test_typescript.py
+++ b/tests/test_typescript.py
@@ -1088,6 +1088,41 @@ export async function resume(req: Request) {
     assert [finding.line for finding in findings] == [2, 3]
 
 
+@pytest.mark.parametrize(
+    "identifier",
+    ["lastEventId", "lastEventID", "LastEventId", "LastEventID", "LAST_EVENT_ID"],
+)
+def test_r014_finds_every_casing_of_the_identifier_in_typescript(tmp_path, identifier):
+    code = f"""\
+export async function resume(req: Request) {{
+  const {identifier} = req.headers.get("x-resume");
+  return replay({identifier});
+}}
+"""
+    project = load_project(
+        _write(tmp_path, "server.ts", code)
+    ).for_language("typescript")
+    findings = SSEResumabilityRemoved().check(project)
+    assert [finding.line for finding in findings] == [2, 3]
+
+
+@pytest.mark.parametrize(
+    "identifier",
+    ["lastEventIdentifier", "lastEventIds", "eventIdCache"],
+)
+def test_r014_leaves_unrelated_identifiers_alone_in_typescript(tmp_path, identifier):
+    code = f"""\
+export function build() {{
+  const {identifier} = new Map();
+  return {identifier};
+}}
+"""
+    project = load_project(
+        _write(tmp_path, "server.ts", code)
+    ).for_language("typescript")
+    assert SSEResumabilityRemoved().check(project) == []
+
+
 def test_r014_stays_silent_on_migrated_typescript_server(tmp_path):
     code = """\
 export async function handle(req: Request) {


### PR DESCRIPTION
Fixes #143.

R014's TypeScript identifier path matched case-sensitively, so it found
`lastEventId` and `LastEventId` but missed `lastEventID` and `LAST_EVENT_ID`.

- `TS_CODE_RX` is now a single bounded pattern, `\blast_?event_?id\b`,
  matched with `re.IGNORECASE` via `search_code(..., flags=...)`.
  The `_?` covers the SCREAMING_SNAKE const form, which the flag alone
  would still miss.
- The header/wire half is unchanged and stays case-sensitive, as the
  issue notes.
- Tests: parametrized over all five casings, plus a negative case
  asserting `lastEventIdentifier` / `lastEventIds` / `eventIdCache`
  do not fire. `\b` anchoring keeps this in the conservative direction.

418 tests pass locally.
