### PR TITLE
fix(scan): load JavaScript source files

### DIFF
--- a/src/mcp_migrate/rules/base.py
+++ b/src/mcp_migrate/rules/base.py
@@ -161,7 +161,8 @@ class Project:
         key = id(f)
         if key not in self._span_cache:
             self._span_cache[key] = (
-                _ts_spans(f.text, prose_only=False) if f.language == "typescript"
+                _ts_spans(f.text, prose_only=False)
+                if f.language in {"typescript", "javascript"}
                 else _content_spans(f.text)
             )
         return self._span_cache[key]
@@ -170,7 +171,8 @@ class Project:
         key = ("prose", id(f))
         if key not in self._span_cache:
             self._span_cache[key] = (
-                _ts_spans(f.text, prose_only=True) if f.language == "typescript"
+                _ts_spans(f.text, prose_only=True)
+                if f.language in {"typescript", "javascript"}
                 else _prose_spans(f.text)
             )
         return self._span_cache[key]

--- a/src/mcp_migrate/scan.py
+++ b/src/mcp_migrate/scan.py
@@ -59,6 +59,8 @@ SOURCE_EXTENSIONS = {
     ".py": "python",
     ".ts": "typescript", ".mts": "typescript", ".cts": "typescript",
     ".tsx": "typescript",
+    ".js": "javascript", ".jsx": "javascript",
+    ".mjs": "javascript", ".cjs": "javascript",
 }
 
 

--- a/tests/test_scan.py
+++ b/tests/test_scan.py
@@ -24,3 +24,34 @@ def test_generated_declarations_are_skipped_for_every_module_form(tmp_path):
     project = load_project(tmp_path)
     scanned = {f.path.name for f in project.files}
     assert scanned == {"impl.ts", "impl.mts", "impl.cts"}
+def test_load_project_reads_javascript_and_skips_declaration_output(tmp_path):
+    (tmp_path / "server.js").write_text("const answer = 42;\n")
+    (tmp_path / "component.jsx").write_text("export default () => null;\n")
+    (tmp_path / "module.mjs").write_text("export const answer = 42;\n")
+    (tmp_path / "common.cjs").write_text("module.exports = {};\n")
+    (tmp_path / "types.d.ts").write_text("export declare const answer: number;\n")
+
+    project = load_project(tmp_path)
+
+    assert [(file.path.name, file.language) for file in project.files] == [
+        ("common.cjs", "javascript"),
+        ("component.jsx", "javascript"),
+        ("module.mjs", "javascript"),
+        ("server.js", "javascript"),
+    ]
+
+
+def test_javascript_uses_the_typescript_comment_and_string_spans(tmp_path):
+    """Loading `.js` is only half the job. If `javascript` did not reach the
+    TypeScript span branch it would fall through to the Python one, and `//`
+    would stop being recognised as a comment -- so a rule would read
+    commented-out code as live. That is #113's failure, one language over,
+    and the extension map alone does not catch it."""
+    (tmp_path / "a.js").write_text(
+        '// const sessionId = req.headers["Mcp-Session-Id"];\n'
+        'const real = 1;\n'
+    )
+    project = load_project(tmp_path)
+    assert list(project.search_code(r"Mcp-Session-Id")) == [], (
+        "a // comment must not read as code on a .js file"
+    )


### PR DESCRIPTION
## Summary
- load js, jsx, mjs, and cjs files as JavaScript source
- use the TypeScript comment and string span scanner for JavaScript
- keep generated d.ts declarations excluded
- add a regression test for all supported JavaScript extensions

Closes #149

## Validation
- PYTHONPATH=src uv run --with pytest --with pyyaml --with rich pytest
- 411 tests passed