### PR TITLE
docs: add executable check --json schema contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,12 @@ contributed.
   the `extensions` map, trace context propagation, and Roots/Sampling/
   Logging deprecation. All eighteen slots are now written; there are no
   stubs left. (@waterlemonnn)
+- **`check --json` now has an executable schema contract** in
+  `schemas/check-json.schema.json`, documented in the README and validated
+  against clean, legacy, unscannable, and SDK outputs. Pre-1.0 compatibility
+  policy is stated next to the contract so external consumers know breaking
+  shape changes will be documented under Changed.
+  ([#188](https://github.com/dheerajjha/mcp-migrate/issues/188))
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -56,6 +56,28 @@ Zero findings prints `Grade A` and a ready-to-paste badge instead. Add
 rule at 5 rows with a "+N more" line so it stays readable; JSON always has
 every finding).
 
+### `check --json` contract
+
+`--json` emits one JSON object with these always-present top-level keys:
+`tool`, `version`, `spec`, `path`, `scannable`, `languages`, `grade`,
+`score`, `files_scanned`, `counts`, and `findings`.
+
+Conditional keys:
+
+- `is_sdk` and `sdk_reason` only when the tree is a protocol SDK. In that case `grade` and `score` are `null`.
+- `reason` only when `scannable` is `false`. In that case `grade` and `score` are `null`.
+- `grade` and `score` are also `null` when a tree was read but is not gradable, for example TypeScript-only trees.
+
+Each finding always has `rule`, `severity`, `path`, `line`, and `message`.
+`path` and `line` may be `null` for project-level findings. `fix` is present
+only when the rule has remediation text; it is omitted, never `null`.
+
+The executable contract is
+[`schemas/check-json.schema.json`](schemas/check-json.schema.json). Pre-1.0,
+this shape may change in a breaking way; such changes are documented under
+Changed in [CHANGELOG.md](CHANGELOG.md), so consumers should pin a version
+and watch that section.
+
 Exit codes, so it drops straight into CI:
 
 | code | meaning |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ dependencies = ["pyyaml>=6.0", "rich>=13.0"]
 mcp-migrate = "mcp_migrate.cli:main"
 
 [project.optional-dependencies]
-dev = ["pytest>=8.0"]
+dev = ["jsonschema>=4.0", "pytest>=8.0"]
 
 [build-system]
 requires = ["hatchling"]

--- a/schemas/check-json.schema.json
+++ b/schemas/check-json.schema.json
@@ -1,0 +1,158 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/dheerajjha/mcp-migrate/schemas/check-json.schema.json",
+  "title": "mcp-migrate check --json output",
+  "type": "object",
+  "required": [
+    "tool",
+    "version",
+    "spec",
+    "path",
+    "scannable",
+    "languages",
+    "grade",
+    "score",
+    "files_scanned",
+    "counts",
+    "findings"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "tool": {
+      "const": "mcp-migrate"
+    },
+    "version": {
+      "type": "string"
+    },
+    "spec": {
+      "const": "2026-07-28"
+    },
+    "path": {
+      "type": "string"
+    },
+    "scannable": {
+      "type": "boolean"
+    },
+    "is_sdk": {
+      "type": "boolean"
+    },
+    "sdk_reason": {
+      "type": "string"
+    },
+    "reason": {
+      "type": "string"
+    },
+    "languages": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "integer",
+        "minimum": 0
+      }
+    },
+    "grade": {
+      "type": ["string", "null"],
+      "pattern": "^[A-F]$"
+    },
+    "score": {
+      "type": ["integer", "null"],
+      "minimum": 0,
+      "maximum": 100
+    },
+    "files_scanned": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "counts": {
+      "type": "object",
+      "required": ["breaking", "deprecated", "advisory"],
+      "additionalProperties": false,
+      "properties": {
+        "breaking": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "deprecated": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "advisory": {
+          "type": "integer",
+          "minimum": 0
+        }
+      }
+    },
+    "findings": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["rule", "severity", "path", "line", "message"],
+        "additionalProperties": false,
+        "properties": {
+          "rule": {
+            "type": "string",
+            "pattern": "^R[0-9]{3}$"
+          },
+          "severity": {
+            "enum": ["breaking", "deprecated", "advisory"]
+          },
+          "path": {
+            "type": ["string", "null"]
+          },
+          "line": {
+            "type": ["integer", "null"]
+          },
+          "message": {
+            "type": "string"
+          },
+          "fix": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  },
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "scannable": {
+            "const": false
+          }
+        },
+        "required": ["scannable"]
+      },
+      "then": {
+        "required": ["reason"],
+        "properties": {
+          "grade": {
+            "const": null
+          },
+          "score": {
+            "const": null
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "is_sdk": {
+            "const": true
+          }
+        },
+        "required": ["is_sdk"]
+      },
+      "then": {
+        "required": ["sdk_reason"],
+        "properties": {
+          "grade": {
+            "const": null
+          },
+          "score": {
+            "const": null
+          }
+        }
+      }
+    }
+  ]
+}

--- a/tests/test_check_json_schema.py
+++ b/tests/test_check_json_schema.py
@@ -1,0 +1,46 @@
+"""Validate real `check --json` output against the checked-in JSON Schema."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import jsonschema
+
+from mcp_migrate.cli import main
+
+ROOT = Path(__file__).resolve().parent.parent
+SCHEMA = json.loads((ROOT / "schemas" / "check-json.schema.json").read_text(encoding="utf-8"))
+FIXTURES = ROOT / "tests" / "fixtures"
+
+
+def _validate(capsys, root: Path) -> dict:
+    exit_code = main(["check", str(root), "--json"])
+    payload = json.loads(capsys.readouterr().out)
+    jsonschema.validate(payload, SCHEMA)
+    return payload
+
+
+def test_schema_validates_clean_output(capsys):
+    payload = _validate(capsys, FIXTURES / "clean_server")
+    assert payload["grade"] == "A"
+    assert payload["findings"] == []
+
+
+def test_schema_validates_finding_output(capsys):
+    payload = _validate(capsys, FIXTURES / "legacy_server")
+    assert payload["findings"]
+    assert all("fix" not in finding or finding["fix"] for finding in payload["findings"])
+
+
+def test_schema_validates_unscannable_output(capsys, tmp_path: Path):
+    payload = _validate(capsys, tmp_path)
+    assert payload["scannable"] is False
+    assert payload["reason"]
+
+
+def test_schema_validates_sdk_output(capsys, tmp_path: Path):
+    (tmp_path / "pyproject.toml").write_text('[project]\nname = "mcp"\n', encoding="utf-8")
+    (tmp_path / "server.py").write_text("import logging\nlogging.basicConfig()\n", encoding="utf-8")
+    payload = _validate(capsys, tmp_path)
+    assert payload["is_sdk"] is True
+    assert payload["sdk_reason"]


### PR DESCRIPTION
## What & why

Makes the `check --json` shape a documented, executable contract instead of a README hint. External scripts now have a stable schema to validate against and a stated pre-1.0 compatibility policy.

Closes #188.

## Changes

- Added `schemas/check-json.schema.json` covering the normal, SDK, and unscannable output variants.
- Added `tests/test_check_json_schema.py`, which validates real output from clean, legacy, empty, and SDK fixtures against the schema.
- Documented the always-present keys, conditional keys, and finding shape in the README, next to the `--json` mention.
- Added `jsonschema` to the dev extra and noted the contract in the CHANGELOG under Unreleased.

## Verification

- `uv sync --extra dev`
- `uv run pytest -q`: 449 passed.
