### PR TITLE
feat(cli): add SARIF 2.1.0 output for GitHub code scanning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,42 @@ All notable changes to this project are documented here.
 
 ## [Unreleased]
 
+### Added
+
+- **SARIF 2.1.0 output: `check --format sarif`.** Findings land in GitHub
+  code scanning as annotations on the diff and entries in the Security tab,
+  tracked across commits instead of re-read from a CI log every time.
+  ([#182](https://github.com/dheerajjha/mcp-migrate/issues/182))
+
+  `--format {text,json,sarif}` is the new surface; `--json` keeps working as
+  an alias for `--format json` and its output is byte-identical. The format
+  decides what is printed and never what is returned — exit codes are
+  unchanged across all three.
+
+  Two decisions worth stating rather than burying:
+
+  - **`deprecated` maps to `warning`, not `error`.** Code scanning's default
+    gate fails on `error` alone, so this mapping decides whether a
+    deprecation blocks a merge. The spec gives deprecated features 12+
+    months; making a server unmergeable today over something that breaks
+    next year gets the integration switched off, and then it catches
+    nothing. `breaking` → `error` and `advisory` → `note`.
+  - **The driver declares all 21 rules, not only those that fired.** That is
+    what lets code scanning tell "this rule ran and found nothing" from
+    "this rule does not exist", and therefore close a resolved alert instead
+    of leaving it open forever. A clean tree still emits a full run with
+    `results: []`.
+
+  Paths are repo-relative and forward-slashed on every platform, because
+  code scanning matches results to the diff by path and an absolute path
+  from the scanning machine matches nothing — the annotations would silently
+  never appear. Project-level findings (R010 asks about the whole tree) are
+  kept with an empty `locations` array rather than dropped.
+
+  Validated in CI against a vendored copy of the official schema at
+  `schemas/sarif-2.1.0.schema.json`; it is checked in rather than fetched so
+  the suite does not depend on the network across four Python versions.
+
 ### Fixed
 
 - **R004 no longer fires on a wire method name that returns no tools.**

--- a/README.md
+++ b/README.md
@@ -78,6 +78,28 @@ this shape may change in a breaking way; such changes are documented under
 Changed in [CHANGELOG.md](CHANGELOG.md), so consumers should pin a version
 and watch that section.
 
+### `check --format sarif`
+
+SARIF 2.1.0, for GitHub code scanning and anything else that speaks it:
+
+```yaml
+- run: mcp-migrate check . --format sarif > mcp-migrate.sarif
+- uses: github/codeql-action/upload-sarif@v3
+  with:
+    sarif_file: mcp-migrate.sarif
+```
+
+Findings land in the Security tab and annotate the diff, instead of scrolling
+past in a log. Severities map to SARIF levels as `breaking` -> `error`,
+`deprecated` -> `warning`, `advisory` -> `note`. `deprecated` is deliberately
+not `error`: code scanning's default gate fails on `error` alone, and the spec
+gives deprecated features 12+ months, so blocking a merge today over a change
+that doesn't break until next year is how an integration gets switched off.
+
+`--format {text,json,sarif}` is the general flag; `--json` remains as an alias
+for `--format json`. Output is validated against the vendored
+[SARIF 2.1.0 schema](schemas/sarif-2.1.0.schema.json) in CI.
+
 Exit codes, so it drops straight into CI:
 
 | code | meaning |

--- a/schemas/sarif-2.1.0.schema.json
+++ b/schemas/sarif-2.1.0.schema.json
@@ -1,0 +1,3012 @@
+{
+  "$id": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "additionalProperties": false,
+  "definitions": {
+    "address": {
+      "additionalProperties": false,
+      "description": "A physical or virtual address, or a range of addresses, in an 'addressable region' (memory or a binary file).",
+      "properties": {
+        "absoluteAddress": {
+          "default": -1,
+          "description": "The address expressed as a byte offset from the start of the addressable region.",
+          "minimum": -1,
+          "type": "integer"
+        },
+        "fullyQualifiedName": {
+          "description": "A human-readable fully qualified name that is associated with the address.",
+          "type": "string"
+        },
+        "index": {
+          "default": -1,
+          "description": "The index within run.addresses of the cached object for this address.",
+          "minimum": -1,
+          "type": "integer"
+        },
+        "kind": {
+          "description": "An open-ended string that identifies the address kind. 'data', 'function', 'header','instruction', 'module', 'page', 'section', 'segment', 'stack', 'stackFrame', 'table' are well-known values.",
+          "type": "string"
+        },
+        "length": {
+          "description": "The number of bytes in this range of addresses.",
+          "type": "integer"
+        },
+        "name": {
+          "description": "A name that is associated with the address, e.g., '.text'.",
+          "type": "string"
+        },
+        "offsetFromParent": {
+          "description": "The byte offset of this address from the absolute or relative address of the parent object.",
+          "type": "integer"
+        },
+        "parentIndex": {
+          "default": -1,
+          "description": "The index within run.addresses of the parent object.",
+          "minimum": -1,
+          "type": "integer"
+        },
+        "properties": {
+          "$ref": "#/definitions/propertyBag",
+          "description": "Key/value pairs that provide additional information about the address."
+        },
+        "relativeAddress": {
+          "description": "The address expressed as a byte offset from the absolute address of the top-most parent object.",
+          "type": "integer"
+        }
+      },
+      "type": "object"
+    },
+    "artifact": {
+      "additionalProperties": false,
+      "description": "A single artifact. In some cases, this artifact might be nested within another artifact.",
+      "properties": {
+        "contents": {
+          "$ref": "#/definitions/artifactContent",
+          "description": "The contents of the artifact."
+        },
+        "description": {
+          "$ref": "#/definitions/message",
+          "description": "A short description of the artifact."
+        },
+        "encoding": {
+          "description": "Specifies the encoding for an artifact object that refers to a text file.",
+          "type": "string"
+        },
+        "hashes": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "A dictionary, each of whose keys is the name of a hash function and each of whose values is the hashed value of the artifact produced by the specified hash function.",
+          "type": "object"
+        },
+        "lastModifiedTimeUtc": {
+          "description": "The Coordinated Universal Time (UTC) date and time at which the artifact was most recently modified. See \"Date/time properties\" in the SARIF spec for the required format.",
+          "format": "date-time",
+          "type": "string"
+        },
+        "length": {
+          "default": -1,
+          "description": "The length of the artifact in bytes.",
+          "minimum": -1,
+          "type": "integer"
+        },
+        "location": {
+          "$ref": "#/definitions/artifactLocation",
+          "description": "The location of the artifact."
+        },
+        "mimeType": {
+          "description": "The MIME type (RFC 2045) of the artifact.",
+          "pattern": "[^/]+/.+",
+          "type": "string"
+        },
+        "offset": {
+          "description": "The offset in bytes of the artifact within its containing artifact.",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "parentIndex": {
+          "default": -1,
+          "description": "Identifies the index of the immediate parent of the artifact, if this artifact is nested.",
+          "minimum": -1,
+          "type": "integer"
+        },
+        "properties": {
+          "$ref": "#/definitions/propertyBag",
+          "description": "Key/value pairs that provide additional information about the artifact."
+        },
+        "roles": {
+          "default": [],
+          "description": "The role or roles played by the artifact in the analysis.",
+          "items": {
+            "enum": [
+              "analysisTarget",
+              "attachment",
+              "responseFile",
+              "resultFile",
+              "standardStream",
+              "tracedFile",
+              "unmodified",
+              "modified",
+              "added",
+              "deleted",
+              "renamed",
+              "uncontrolled",
+              "driver",
+              "extension",
+              "translation",
+              "taxonomy",
+              "policy",
+              "referencedOnCommandLine",
+              "memoryContents",
+              "directory",
+              "userSpecifiedConfiguration",
+              "toolSpecifiedConfiguration",
+              "debugOutputFile"
+            ]
+          },
+          "minItems": 0,
+          "type": "array",
+          "uniqueItems": true
+        },
+        "sourceLanguage": {
+          "description": "Specifies the source language for any artifact object that refers to a text file that contains source code.",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "artifactChange": {
+      "additionalProperties": false,
+      "description": "A change to a single artifact.",
+      "properties": {
+        "artifactLocation": {
+          "$ref": "#/definitions/artifactLocation",
+          "description": "The location of the artifact to change."
+        },
+        "properties": {
+          "$ref": "#/definitions/propertyBag",
+          "description": "Key/value pairs that provide additional information about the change."
+        },
+        "replacements": {
+          "description": "An array of replacement objects, each of which represents the replacement of a single region in a single artifact specified by 'artifactLocation'.",
+          "items": {
+            "$ref": "#/definitions/replacement"
+          },
+          "minItems": 1,
+          "type": "array",
+          "uniqueItems": false
+        }
+      },
+      "required": [
+        "artifactLocation",
+        "replacements"
+      ],
+      "type": "object"
+    },
+    "artifactContent": {
+      "additionalProperties": false,
+      "description": "Represents the contents of an artifact.",
+      "properties": {
+        "binary": {
+          "description": "MIME Base64-encoded content from a binary artifact, or from a text artifact in its original encoding.",
+          "type": "string"
+        },
+        "properties": {
+          "$ref": "#/definitions/propertyBag",
+          "description": "Key/value pairs that provide additional information about the artifact content."
+        },
+        "rendered": {
+          "$ref": "#/definitions/multiformatMessageString",
+          "description": "An alternate rendered representation of the artifact (e.g., a decompiled representation of a binary region)."
+        },
+        "text": {
+          "description": "UTF-8-encoded content from a text artifact.",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "artifactLocation": {
+      "additionalProperties": false,
+      "description": "Specifies the location of an artifact.",
+      "properties": {
+        "description": {
+          "$ref": "#/definitions/message",
+          "description": "A short description of the artifact location."
+        },
+        "index": {
+          "default": -1,
+          "description": "The index within the run artifacts array of the artifact object associated with the artifact location.",
+          "minimum": -1,
+          "type": "integer"
+        },
+        "properties": {
+          "$ref": "#/definitions/propertyBag",
+          "description": "Key/value pairs that provide additional information about the artifact location."
+        },
+        "uri": {
+          "description": "A string containing a valid relative or absolute URI.",
+          "format": "uri-reference",
+          "type": "string"
+        },
+        "uriBaseId": {
+          "description": "A string which indirectly specifies the absolute URI with respect to which a relative URI in the \"uri\" property is interpreted.",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "attachment": {
+      "additionalProperties": false,
+      "description": "An artifact relevant to a result.",
+      "properties": {
+        "artifactLocation": {
+          "$ref": "#/definitions/artifactLocation",
+          "description": "The location of the attachment."
+        },
+        "description": {
+          "$ref": "#/definitions/message",
+          "description": "A message describing the role played by the attachment."
+        },
+        "properties": {
+          "$ref": "#/definitions/propertyBag",
+          "description": "Key/value pairs that provide additional information about the attachment."
+        },
+        "rectangles": {
+          "default": [],
+          "description": "An array of rectangles specifying areas of interest within the image.",
+          "items": {
+            "$ref": "#/definitions/rectangle"
+          },
+          "minItems": 0,
+          "type": "array",
+          "uniqueItems": true
+        },
+        "regions": {
+          "default": [],
+          "description": "An array of regions of interest within the attachment.",
+          "items": {
+            "$ref": "#/definitions/region"
+          },
+          "minItems": 0,
+          "type": "array",
+          "uniqueItems": true
+        }
+      },
+      "required": [
+        "artifactLocation"
+      ],
+      "type": "object"
+    },
+    "codeFlow": {
+      "additionalProperties": false,
+      "description": "A set of threadFlows which together describe a pattern of code execution relevant to detecting a result.",
+      "properties": {
+        "message": {
+          "$ref": "#/definitions/message",
+          "description": "A message relevant to the code flow."
+        },
+        "properties": {
+          "$ref": "#/definitions/propertyBag",
+          "description": "Key/value pairs that provide additional information about the code flow."
+        },
+        "threadFlows": {
+          "description": "An array of one or more unique threadFlow objects, each of which describes the progress of a program through a thread of execution.",
+          "items": {
+            "$ref": "#/definitions/threadFlow"
+          },
+          "minItems": 1,
+          "type": "array",
+          "uniqueItems": false
+        }
+      },
+      "required": [
+        "threadFlows"
+      ],
+      "type": "object"
+    },
+    "configurationOverride": {
+      "additionalProperties": false,
+      "description": "Information about how a specific rule or notification was reconfigured at runtime.",
+      "properties": {
+        "configuration": {
+          "$ref": "#/definitions/reportingConfiguration",
+          "description": "Specifies how the rule or notification was configured during the scan."
+        },
+        "descriptor": {
+          "$ref": "#/definitions/reportingDescriptorReference",
+          "description": "A reference used to locate the descriptor whose configuration was overridden."
+        },
+        "properties": {
+          "$ref": "#/definitions/propertyBag",
+          "description": "Key/value pairs that provide additional information about the configuration override."
+        }
+      },
+      "required": [
+        "configuration",
+        "descriptor"
+      ],
+      "type": "object"
+    },
+    "conversion": {
+      "additionalProperties": false,
+      "description": "Describes how a converter transformed the output of a static analysis tool from the analysis tool's native output format into the SARIF format.",
+      "properties": {
+        "analysisToolLogFiles": {
+          "default": [],
+          "description": "The locations of the analysis tool's per-run log files.",
+          "items": {
+            "$ref": "#/definitions/artifactLocation"
+          },
+          "minItems": 0,
+          "type": "array",
+          "uniqueItems": true
+        },
+        "invocation": {
+          "$ref": "#/definitions/invocation",
+          "description": "An invocation object that describes the invocation of the converter."
+        },
+        "properties": {
+          "$ref": "#/definitions/propertyBag",
+          "description": "Key/value pairs that provide additional information about the conversion."
+        },
+        "tool": {
+          "$ref": "#/definitions/tool",
+          "description": "A tool object that describes the converter."
+        }
+      },
+      "required": [
+        "tool"
+      ],
+      "type": "object"
+    },
+    "edge": {
+      "additionalProperties": false,
+      "description": "Represents a directed edge in a graph.",
+      "properties": {
+        "id": {
+          "description": "A string that uniquely identifies the edge within its graph.",
+          "type": "string"
+        },
+        "label": {
+          "$ref": "#/definitions/message",
+          "description": "A short description of the edge."
+        },
+        "properties": {
+          "$ref": "#/definitions/propertyBag",
+          "description": "Key/value pairs that provide additional information about the edge."
+        },
+        "sourceNodeId": {
+          "description": "Identifies the source node (the node at which the edge starts).",
+          "type": "string"
+        },
+        "targetNodeId": {
+          "description": "Identifies the target node (the node at which the edge ends).",
+          "type": "string"
+        }
+      },
+      "required": [
+        "id",
+        "sourceNodeId",
+        "targetNodeId"
+      ],
+      "type": "object"
+    },
+    "edgeTraversal": {
+      "additionalProperties": false,
+      "description": "Represents the traversal of a single edge during a graph traversal.",
+      "properties": {
+        "edgeId": {
+          "description": "Identifies the edge being traversed.",
+          "type": "string"
+        },
+        "finalState": {
+          "additionalProperties": {
+            "$ref": "#/definitions/multiformatMessageString"
+          },
+          "description": "The values of relevant expressions after the edge has been traversed.",
+          "type": "object"
+        },
+        "message": {
+          "$ref": "#/definitions/message",
+          "description": "A message to display to the user as the edge is traversed."
+        },
+        "properties": {
+          "$ref": "#/definitions/propertyBag",
+          "description": "Key/value pairs that provide additional information about the edge traversal."
+        },
+        "stepOverEdgeCount": {
+          "description": "The number of edge traversals necessary to return from a nested graph.",
+          "minimum": 0,
+          "type": "integer"
+        }
+      },
+      "required": [
+        "edgeId"
+      ],
+      "type": "object"
+    },
+    "exception": {
+      "additionalProperties": false,
+      "description": "Describes a runtime exception encountered during the execution of an analysis tool.",
+      "properties": {
+        "innerExceptions": {
+          "default": [],
+          "description": "An array of exception objects each of which is considered a cause of this exception.",
+          "items": {
+            "$ref": "#/definitions/exception"
+          },
+          "minItems": 0,
+          "type": "array",
+          "uniqueItems": false
+        },
+        "kind": {
+          "description": "A string that identifies the kind of exception, for example, the fully qualified type name of an object that was thrown, or the symbolic name of a signal.",
+          "type": "string"
+        },
+        "message": {
+          "description": "A message that describes the exception.",
+          "type": "string"
+        },
+        "properties": {
+          "$ref": "#/definitions/propertyBag",
+          "description": "Key/value pairs that provide additional information about the exception."
+        },
+        "stack": {
+          "$ref": "#/definitions/stack",
+          "description": "The sequence of function calls leading to the exception."
+        }
+      },
+      "type": "object"
+    },
+    "externalProperties": {
+      "additionalProperties": false,
+      "description": "The top-level element of an external property file.",
+      "properties": {
+        "addresses": {
+          "default": [],
+          "description": "Addresses that will be merged with a separate run.",
+          "items": {
+            "$ref": "#/definitions/address"
+          },
+          "minItems": 0,
+          "type": "array",
+          "uniqueItems": false
+        },
+        "artifacts": {
+          "description": "An array of artifact objects that will be merged with a separate run.",
+          "items": {
+            "$ref": "#/definitions/artifact"
+          },
+          "minItems": 0,
+          "type": "array",
+          "uniqueItems": true
+        },
+        "conversion": {
+          "$ref": "#/definitions/conversion",
+          "description": "A conversion object that will be merged with a separate run."
+        },
+        "driver": {
+          "$ref": "#/definitions/toolComponent",
+          "description": "The analysis tool object that will be merged with a separate run."
+        },
+        "extensions": {
+          "default": [],
+          "description": "Tool extensions that will be merged with a separate run.",
+          "items": {
+            "$ref": "#/definitions/toolComponent"
+          },
+          "minItems": 0,
+          "type": "array",
+          "uniqueItems": true
+        },
+        "externalizedProperties": {
+          "$ref": "#/definitions/propertyBag",
+          "description": "Key/value pairs that provide additional information that will be merged with a separate run."
+        },
+        "graphs": {
+          "default": [],
+          "description": "An array of graph objects that will be merged with a separate run.",
+          "items": {
+            "$ref": "#/definitions/graph"
+          },
+          "minItems": 0,
+          "type": "array",
+          "uniqueItems": true
+        },
+        "guid": {
+          "description": "A stable, unique identifier for this external properties object, in the form of a GUID.",
+          "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$",
+          "type": "string"
+        },
+        "invocations": {
+          "default": [],
+          "description": "Describes the invocation of the analysis tool that will be merged with a separate run.",
+          "items": {
+            "$ref": "#/definitions/invocation"
+          },
+          "minItems": 0,
+          "type": "array",
+          "uniqueItems": false
+        },
+        "logicalLocations": {
+          "default": [],
+          "description": "An array of logical locations such as namespaces, types or functions that will be merged with a separate run.",
+          "items": {
+            "$ref": "#/definitions/logicalLocation"
+          },
+          "minItems": 0,
+          "type": "array",
+          "uniqueItems": true
+        },
+        "policies": {
+          "default": [],
+          "description": "Tool policies that will be merged with a separate run.",
+          "items": {
+            "$ref": "#/definitions/toolComponent"
+          },
+          "minItems": 0,
+          "type": "array",
+          "uniqueItems": true
+        },
+        "properties": {
+          "$ref": "#/definitions/propertyBag",
+          "description": "Key/value pairs that provide additional information about the external properties."
+        },
+        "results": {
+          "default": [],
+          "description": "An array of result objects that will be merged with a separate run.",
+          "items": {
+            "$ref": "#/definitions/result"
+          },
+          "minItems": 0,
+          "type": "array",
+          "uniqueItems": false
+        },
+        "runGuid": {
+          "description": "A stable, unique identifier for the run associated with this external properties object, in the form of a GUID.",
+          "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$",
+          "type": "string"
+        },
+        "schema": {
+          "description": "The URI of the JSON schema corresponding to the version of the external property file format.",
+          "format": "uri",
+          "type": "string"
+        },
+        "taxonomies": {
+          "default": [],
+          "description": "Tool taxonomies that will be merged with a separate run.",
+          "items": {
+            "$ref": "#/definitions/toolComponent"
+          },
+          "minItems": 0,
+          "type": "array",
+          "uniqueItems": true
+        },
+        "threadFlowLocations": {
+          "default": [],
+          "description": "An array of threadFlowLocation objects that will be merged with a separate run.",
+          "items": {
+            "$ref": "#/definitions/threadFlowLocation"
+          },
+          "minItems": 0,
+          "type": "array",
+          "uniqueItems": true
+        },
+        "translations": {
+          "default": [],
+          "description": "Tool translations that will be merged with a separate run.",
+          "items": {
+            "$ref": "#/definitions/toolComponent"
+          },
+          "minItems": 0,
+          "type": "array",
+          "uniqueItems": true
+        },
+        "version": {
+          "description": "The SARIF format version of this external properties object.",
+          "enum": [
+            "2.1.0"
+          ]
+        },
+        "webRequests": {
+          "default": [],
+          "description": "Requests that will be merged with a separate run.",
+          "items": {
+            "$ref": "#/definitions/webRequest"
+          },
+          "minItems": 0,
+          "type": "array",
+          "uniqueItems": true
+        },
+        "webResponses": {
+          "default": [],
+          "description": "Responses that will be merged with a separate run.",
+          "items": {
+            "$ref": "#/definitions/webResponse"
+          },
+          "minItems": 0,
+          "type": "array",
+          "uniqueItems": true
+        }
+      },
+      "type": "object"
+    },
+    "externalPropertyFileReference": {
+      "additionalProperties": false,
+      "anyOf": [
+        {
+          "required": [
+            "location"
+          ]
+        },
+        {
+          "required": [
+            "guid"
+          ]
+        }
+      ],
+      "description": "Contains information that enables a SARIF consumer to locate the external property file that contains the value of an externalized property associated with the run.",
+      "properties": {
+        "guid": {
+          "description": "A stable, unique identifier for the external property file in the form of a GUID.",
+          "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$",
+          "type": "string"
+        },
+        "itemCount": {
+          "default": -1,
+          "description": "A non-negative integer specifying the number of items contained in the external property file.",
+          "minimum": -1,
+          "type": "integer"
+        },
+        "location": {
+          "$ref": "#/definitions/artifactLocation",
+          "description": "The location of the external property file."
+        },
+        "properties": {
+          "$ref": "#/definitions/propertyBag",
+          "description": "Key/value pairs that provide additional information about the external property file."
+        }
+      },
+      "type": "object"
+    },
+    "externalPropertyFileReferences": {
+      "additionalProperties": false,
+      "description": "References to external property files that should be inlined with the content of a root log file.",
+      "properties": {
+        "addresses": {
+          "default": [],
+          "description": "An array of external property files containing run.addresses arrays to be merged with the root log file.",
+          "items": {
+            "$ref": "#/definitions/externalPropertyFileReference"
+          },
+          "minItems": 0,
+          "type": "array",
+          "uniqueItems": true
+        },
+        "artifacts": {
+          "default": [],
+          "description": "An array of external property files containing run.artifacts arrays to be merged with the root log file.",
+          "items": {
+            "$ref": "#/definitions/externalPropertyFileReference"
+          },
+          "minItems": 0,
+          "type": "array",
+          "uniqueItems": true
+        },
+        "conversion": {
+          "$ref": "#/definitions/externalPropertyFileReference",
+          "description": "An external property file containing a run.conversion object to be merged with the root log file."
+        },
+        "driver": {
+          "$ref": "#/definitions/externalPropertyFileReference",
+          "description": "An external property file containing a run.driver object to be merged with the root log file."
+        },
+        "extensions": {
+          "default": [],
+          "description": "An array of external property files containing run.extensions arrays to be merged with the root log file.",
+          "items": {
+            "$ref": "#/definitions/externalPropertyFileReference"
+          },
+          "minItems": 0,
+          "type": "array",
+          "uniqueItems": true
+        },
+        "externalizedProperties": {
+          "$ref": "#/definitions/externalPropertyFileReference",
+          "description": "An external property file containing a run.properties object to be merged with the root log file."
+        },
+        "graphs": {
+          "default": [],
+          "description": "An array of external property files containing a run.graphs object to be merged with the root log file.",
+          "items": {
+            "$ref": "#/definitions/externalPropertyFileReference"
+          },
+          "minItems": 0,
+          "type": "array",
+          "uniqueItems": true
+        },
+        "invocations": {
+          "default": [],
+          "description": "An array of external property files containing run.invocations arrays to be merged with the root log file.",
+          "items": {
+            "$ref": "#/definitions/externalPropertyFileReference"
+          },
+          "minItems": 0,
+          "type": "array",
+          "uniqueItems": true
+        },
+        "logicalLocations": {
+          "default": [],
+          "description": "An array of external property files containing run.logicalLocations arrays to be merged with the root log file.",
+          "items": {
+            "$ref": "#/definitions/externalPropertyFileReference"
+          },
+          "minItems": 0,
+          "type": "array",
+          "uniqueItems": true
+        },
+        "policies": {
+          "default": [],
+          "description": "An array of external property files containing run.policies arrays to be merged with the root log file.",
+          "items": {
+            "$ref": "#/definitions/externalPropertyFileReference"
+          },
+          "minItems": 0,
+          "type": "array",
+          "uniqueItems": true
+        },
+        "properties": {
+          "$ref": "#/definitions/propertyBag",
+          "description": "Key/value pairs that provide additional information about the external property files."
+        },
+        "results": {
+          "default": [],
+          "description": "An array of external property files containing run.results arrays to be merged with the root log file.",
+          "items": {
+            "$ref": "#/definitions/externalPropertyFileReference"
+          },
+          "minItems": 0,
+          "type": "array",
+          "uniqueItems": true
+        },
+        "taxonomies": {
+          "default": [],
+          "description": "An array of external property files containing run.taxonomies arrays to be merged with the root log file.",
+          "items": {
+            "$ref": "#/definitions/externalPropertyFileReference"
+          },
+          "minItems": 0,
+          "type": "array",
+          "uniqueItems": true
+        },
+        "threadFlowLocations": {
+          "default": [],
+          "description": "An array of external property files containing run.threadFlowLocations arrays to be merged with the root log file.",
+          "items": {
+            "$ref": "#/definitions/externalPropertyFileReference"
+          },
+          "minItems": 0,
+          "type": "array",
+          "uniqueItems": true
+        },
+        "translations": {
+          "default": [],
+          "description": "An array of external property files containing run.translations arrays to be merged with the root log file.",
+          "items": {
+            "$ref": "#/definitions/externalPropertyFileReference"
+          },
+          "minItems": 0,
+          "type": "array",
+          "uniqueItems": true
+        },
+        "webRequests": {
+          "default": [],
+          "description": "An array of external property files containing run.requests arrays to be merged with the root log file.",
+          "items": {
+            "$ref": "#/definitions/externalPropertyFileReference"
+          },
+          "minItems": 0,
+          "type": "array",
+          "uniqueItems": true
+        },
+        "webResponses": {
+          "default": [],
+          "description": "An array of external property files containing run.responses arrays to be merged with the root log file.",
+          "items": {
+            "$ref": "#/definitions/externalPropertyFileReference"
+          },
+          "minItems": 0,
+          "type": "array",
+          "uniqueItems": true
+        }
+      },
+      "type": "object"
+    },
+    "fix": {
+      "additionalProperties": false,
+      "description": "A proposed fix for the problem represented by a result object. A fix specifies a set of artifacts to modify. For each artifact, it specifies a set of bytes to remove, and provides a set of new bytes to replace them.",
+      "properties": {
+        "artifactChanges": {
+          "description": "One or more artifact changes that comprise a fix for a result.",
+          "items": {
+            "$ref": "#/definitions/artifactChange"
+          },
+          "minItems": 1,
+          "type": "array",
+          "uniqueItems": true
+        },
+        "description": {
+          "$ref": "#/definitions/message",
+          "description": "A message that describes the proposed fix, enabling viewers to present the proposed change to an end user."
+        },
+        "properties": {
+          "$ref": "#/definitions/propertyBag",
+          "description": "Key/value pairs that provide additional information about the fix."
+        }
+      },
+      "required": [
+        "artifactChanges"
+      ],
+      "type": "object"
+    },
+    "graph": {
+      "additionalProperties": false,
+      "description": "A network of nodes and directed edges that describes some aspect of the structure of the code (for example, a call graph).",
+      "properties": {
+        "description": {
+          "$ref": "#/definitions/message",
+          "description": "A description of the graph."
+        },
+        "edges": {
+          "default": [],
+          "description": "An array of edge objects representing the edges of the graph.",
+          "items": {
+            "$ref": "#/definitions/edge"
+          },
+          "minItems": 0,
+          "type": "array",
+          "uniqueItems": true
+        },
+        "nodes": {
+          "default": [],
+          "description": "An array of node objects representing the nodes of the graph.",
+          "items": {
+            "$ref": "#/definitions/node"
+          },
+          "minItems": 0,
+          "type": "array",
+          "uniqueItems": true
+        },
+        "properties": {
+          "$ref": "#/definitions/propertyBag",
+          "description": "Key/value pairs that provide additional information about the graph."
+        }
+      },
+      "type": "object"
+    },
+    "graphTraversal": {
+      "additionalProperties": false,
+      "description": "Represents a path through a graph.",
+      "oneOf": [
+        {
+          "required": [
+            "runGraphIndex"
+          ]
+        },
+        {
+          "required": [
+            "resultGraphIndex"
+          ]
+        }
+      ],
+      "properties": {
+        "description": {
+          "$ref": "#/definitions/message",
+          "description": "A description of this graph traversal."
+        },
+        "edgeTraversals": {
+          "default": [],
+          "description": "The sequences of edges traversed by this graph traversal.",
+          "items": {
+            "$ref": "#/definitions/edgeTraversal"
+          },
+          "minItems": 0,
+          "type": "array",
+          "uniqueItems": false
+        },
+        "immutableState": {
+          "additionalProperties": {
+            "$ref": "#/definitions/multiformatMessageString"
+          },
+          "description": "Values of relevant expressions at the start of the graph traversal that remain constant for the graph traversal.",
+          "type": "object"
+        },
+        "initialState": {
+          "additionalProperties": {
+            "$ref": "#/definitions/multiformatMessageString"
+          },
+          "description": "Values of relevant expressions at the start of the graph traversal that may change during graph traversal.",
+          "type": "object"
+        },
+        "properties": {
+          "$ref": "#/definitions/propertyBag",
+          "description": "Key/value pairs that provide additional information about the graph traversal."
+        },
+        "resultGraphIndex": {
+          "default": -1,
+          "description": "The index within the result.graphs to be associated with the result.",
+          "minimum": -1,
+          "type": "integer"
+        },
+        "runGraphIndex": {
+          "default": -1,
+          "description": "The index within the run.graphs to be associated with the result.",
+          "minimum": -1,
+          "type": "integer"
+        }
+      },
+      "type": "object"
+    },
+    "invocation": {
+      "additionalProperties": false,
+      "description": "The runtime environment of the analysis tool run.",
+      "properties": {
+        "account": {
+          "description": "The account under which the invocation occurred.",
+          "type": "string"
+        },
+        "arguments": {
+          "description": "An array of strings, containing in order the command line arguments passed to the tool from the operating system.",
+          "items": {
+            "type": "string"
+          },
+          "minItems": 0,
+          "type": "array",
+          "uniqueItems": false
+        },
+        "commandLine": {
+          "description": "The command line used to invoke the tool.",
+          "type": "string"
+        },
+        "endTimeUtc": {
+          "description": "The Coordinated Universal Time (UTC) date and time at which the invocation ended. See \"Date/time properties\" in the SARIF spec for the required format.",
+          "format": "date-time",
+          "type": "string"
+        },
+        "environmentVariables": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "The environment variables associated with the analysis tool process, expressed as key/value pairs.",
+          "type": "object"
+        },
+        "executableLocation": {
+          "$ref": "#/definitions/artifactLocation",
+          "description": "An absolute URI specifying the location of the executable that was invoked."
+        },
+        "executionSuccessful": {
+          "description": "Specifies whether the tool's execution completed successfully.",
+          "type": "boolean"
+        },
+        "exitCode": {
+          "description": "The process exit code.",
+          "type": "integer"
+        },
+        "exitCodeDescription": {
+          "description": "The reason for the process exit.",
+          "type": "string"
+        },
+        "exitSignalName": {
+          "description": "The name of the signal that caused the process to exit.",
+          "type": "string"
+        },
+        "exitSignalNumber": {
+          "description": "The numeric value of the signal that caused the process to exit.",
+          "type": "integer"
+        },
+        "machine": {
+          "description": "The machine on which the invocation occurred.",
+          "type": "string"
+        },
+        "notificationConfigurationOverrides": {
+          "default": [],
+          "description": "An array of configurationOverride objects that describe notifications related runtime overrides.",
+          "items": {
+            "$ref": "#/definitions/configurationOverride"
+          },
+          "minItems": 0,
+          "type": "array",
+          "uniqueItems": true
+        },
+        "processId": {
+          "description": "The id of the process in which the invocation occurred.",
+          "type": "integer"
+        },
+        "processStartFailureMessage": {
+          "description": "The reason given by the operating system that the process failed to start.",
+          "type": "string"
+        },
+        "properties": {
+          "$ref": "#/definitions/propertyBag",
+          "description": "Key/value pairs that provide additional information about the invocation."
+        },
+        "responseFiles": {
+          "description": "The locations of any response files specified on the tool's command line.",
+          "items": {
+            "$ref": "#/definitions/artifactLocation"
+          },
+          "minItems": 0,
+          "type": "array",
+          "uniqueItems": true
+        },
+        "ruleConfigurationOverrides": {
+          "default": [],
+          "description": "An array of configurationOverride objects that describe rules related runtime overrides.",
+          "items": {
+            "$ref": "#/definitions/configurationOverride"
+          },
+          "minItems": 0,
+          "type": "array",
+          "uniqueItems": true
+        },
+        "startTimeUtc": {
+          "description": "The Coordinated Universal Time (UTC) date and time at which the invocation started. See \"Date/time properties\" in the SARIF spec for the required format.",
+          "format": "date-time",
+          "type": "string"
+        },
+        "stderr": {
+          "$ref": "#/definitions/artifactLocation",
+          "description": "A file containing the standard error stream from the process that was invoked."
+        },
+        "stdin": {
+          "$ref": "#/definitions/artifactLocation",
+          "description": "A file containing the standard input stream to the process that was invoked."
+        },
+        "stdout": {
+          "$ref": "#/definitions/artifactLocation",
+          "description": "A file containing the standard output stream from the process that was invoked."
+        },
+        "stdoutStderr": {
+          "$ref": "#/definitions/artifactLocation",
+          "description": "A file containing the interleaved standard output and standard error stream from the process that was invoked."
+        },
+        "toolConfigurationNotifications": {
+          "default": [],
+          "description": "A list of conditions detected by the tool that are relevant to the tool's configuration.",
+          "items": {
+            "$ref": "#/definitions/notification"
+          },
+          "minItems": 0,
+          "type": "array",
+          "uniqueItems": false
+        },
+        "toolExecutionNotifications": {
+          "default": [],
+          "description": "A list of runtime conditions detected by the tool during the analysis.",
+          "items": {
+            "$ref": "#/definitions/notification"
+          },
+          "minItems": 0,
+          "type": "array",
+          "uniqueItems": false
+        },
+        "workingDirectory": {
+          "$ref": "#/definitions/artifactLocation",
+          "description": "The working directory for the invocation."
+        }
+      },
+      "required": [
+        "executionSuccessful"
+      ],
+      "type": "object"
+    },
+    "location": {
+      "additionalProperties": false,
+      "description": "A location within a programming artifact.",
+      "properties": {
+        "annotations": {
+          "default": [],
+          "description": "A set of regions relevant to the location.",
+          "items": {
+            "$ref": "#/definitions/region"
+          },
+          "minItems": 0,
+          "type": "array",
+          "uniqueItems": true
+        },
+        "id": {
+          "default": -1,
+          "description": "Value that distinguishes this location from all other locations within a single result object.",
+          "minimum": -1,
+          "type": "integer"
+        },
+        "logicalLocations": {
+          "default": [],
+          "description": "The logical locations associated with the result.",
+          "items": {
+            "$ref": "#/definitions/logicalLocation"
+          },
+          "minItems": 0,
+          "type": "array",
+          "uniqueItems": true
+        },
+        "message": {
+          "$ref": "#/definitions/message",
+          "description": "A message relevant to the location."
+        },
+        "physicalLocation": {
+          "$ref": "#/definitions/physicalLocation",
+          "description": "Identifies the artifact and region."
+        },
+        "properties": {
+          "$ref": "#/definitions/propertyBag",
+          "description": "Key/value pairs that provide additional information about the location."
+        },
+        "relationships": {
+          "default": [],
+          "description": "An array of objects that describe relationships between this location and others.",
+          "items": {
+            "$ref": "#/definitions/locationRelationship"
+          },
+          "minItems": 0,
+          "type": "array",
+          "uniqueItems": true
+        }
+      },
+      "type": "object"
+    },
+    "locationRelationship": {
+      "additionalProperties": false,
+      "description": "Information about the relation of one location to another.",
+      "properties": {
+        "description": {
+          "$ref": "#/definitions/message",
+          "description": "A description of the location relationship."
+        },
+        "kinds": {
+          "default": [
+            "relevant"
+          ],
+          "description": "A set of distinct strings that categorize the relationship. Well-known kinds include 'includes', 'isIncludedBy' and 'relevant'.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "uniqueItems": true
+        },
+        "properties": {
+          "$ref": "#/definitions/propertyBag",
+          "description": "Key/value pairs that provide additional information about the location relationship."
+        },
+        "target": {
+          "description": "A reference to the related location.",
+          "minimum": 0,
+          "type": "integer"
+        }
+      },
+      "required": [
+        "target"
+      ],
+      "type": "object"
+    },
+    "logicalLocation": {
+      "additionalProperties": false,
+      "description": "A logical location of a construct that produced a result.",
+      "properties": {
+        "decoratedName": {
+          "description": "The machine-readable name for the logical location, such as a mangled function name provided by a C++ compiler that encodes calling convention, return type and other details along with the function name.",
+          "type": "string"
+        },
+        "fullyQualifiedName": {
+          "description": "The human-readable fully qualified name of the logical location.",
+          "type": "string"
+        },
+        "index": {
+          "default": -1,
+          "description": "The index within the logical locations array.",
+          "minimum": -1,
+          "type": "integer"
+        },
+        "kind": {
+          "description": "The type of construct this logical location component refers to. Should be one of 'function', 'member', 'module', 'namespace', 'parameter', 'resource', 'returnType', 'type', 'variable', 'object', 'array', 'property', 'value', 'element', 'text', 'attribute', 'comment', 'declaration', 'dtd' or 'processingInstruction', if any of those accurately describe the construct.",
+          "type": "string"
+        },
+        "name": {
+          "description": "Identifies the construct in which the result occurred. For example, this property might contain the name of a class or a method.",
+          "type": "string"
+        },
+        "parentIndex": {
+          "default": -1,
+          "description": "Identifies the index of the immediate parent of the construct in which the result was detected. For example, this property might point to a logical location that represents the namespace that holds a type.",
+          "minimum": -1,
+          "type": "integer"
+        },
+        "properties": {
+          "$ref": "#/definitions/propertyBag",
+          "description": "Key/value pairs that provide additional information about the logical location."
+        }
+      },
+      "type": "object"
+    },
+    "message": {
+      "additionalProperties": false,
+      "anyOf": [
+        {
+          "required": [
+            "text"
+          ]
+        },
+        {
+          "required": [
+            "id"
+          ]
+        }
+      ],
+      "description": "Encapsulates a message intended to be read by the end user.",
+      "properties": {
+        "arguments": {
+          "default": [],
+          "description": "An array of strings to substitute into the message string.",
+          "items": {
+            "type": "string"
+          },
+          "minItems": 0,
+          "type": "array",
+          "uniqueItems": false
+        },
+        "id": {
+          "description": "The identifier for this message.",
+          "type": "string"
+        },
+        "markdown": {
+          "description": "A Markdown message string.",
+          "type": "string"
+        },
+        "properties": {
+          "$ref": "#/definitions/propertyBag",
+          "description": "Key/value pairs that provide additional information about the message."
+        },
+        "text": {
+          "description": "A plain text message string.",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "multiformatMessageString": {
+      "additionalProperties": false,
+      "description": "A message string or message format string rendered in multiple formats.",
+      "properties": {
+        "markdown": {
+          "description": "A Markdown message string or format string.",
+          "type": "string"
+        },
+        "properties": {
+          "$ref": "#/definitions/propertyBag",
+          "description": "Key/value pairs that provide additional information about the message."
+        },
+        "text": {
+          "description": "A plain text message string or format string.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "text"
+      ],
+      "type": "object"
+    },
+    "node": {
+      "additionalProperties": false,
+      "description": "Represents a node in a graph.",
+      "properties": {
+        "children": {
+          "default": [],
+          "description": "Array of child nodes.",
+          "items": {
+            "$ref": "#/definitions/node"
+          },
+          "minItems": 0,
+          "type": "array",
+          "uniqueItems": true
+        },
+        "id": {
+          "description": "A string that uniquely identifies the node within its graph.",
+          "type": "string"
+        },
+        "label": {
+          "$ref": "#/definitions/message",
+          "description": "A short description of the node."
+        },
+        "location": {
+          "$ref": "#/definitions/location",
+          "description": "A code location associated with the node."
+        },
+        "properties": {
+          "$ref": "#/definitions/propertyBag",
+          "description": "Key/value pairs that provide additional information about the node."
+        }
+      },
+      "required": [
+        "id"
+      ],
+      "type": "object"
+    },
+    "notification": {
+      "additionalProperties": false,
+      "description": "Describes a condition relevant to the tool itself, as opposed to being relevant to a target being analyzed by the tool.",
+      "properties": {
+        "associatedRule": {
+          "$ref": "#/definitions/reportingDescriptorReference",
+          "description": "A reference used to locate the rule descriptor associated with this notification."
+        },
+        "descriptor": {
+          "$ref": "#/definitions/reportingDescriptorReference",
+          "description": "A reference used to locate the descriptor relevant to this notification."
+        },
+        "exception": {
+          "$ref": "#/definitions/exception",
+          "description": "The runtime exception, if any, relevant to this notification."
+        },
+        "level": {
+          "default": "warning",
+          "description": "A value specifying the severity level of the notification.",
+          "enum": [
+            "none",
+            "note",
+            "warning",
+            "error"
+          ]
+        },
+        "locations": {
+          "default": [],
+          "description": "The locations relevant to this notification.",
+          "items": {
+            "$ref": "#/definitions/location"
+          },
+          "minItems": 0,
+          "type": "array",
+          "uniqueItems": true
+        },
+        "message": {
+          "$ref": "#/definitions/message",
+          "description": "A message that describes the condition that was encountered."
+        },
+        "properties": {
+          "$ref": "#/definitions/propertyBag",
+          "description": "Key/value pairs that provide additional information about the notification."
+        },
+        "threadId": {
+          "description": "The thread identifier of the code that generated the notification.",
+          "type": "integer"
+        },
+        "timeUtc": {
+          "description": "The Coordinated Universal Time (UTC) date and time at which the analysis tool generated the notification.",
+          "format": "date-time",
+          "type": "string"
+        }
+      },
+      "required": [
+        "message"
+      ],
+      "type": "object"
+    },
+    "physicalLocation": {
+      "additionalProperties": false,
+      "anyOf": [
+        {
+          "required": [
+            "address"
+          ]
+        },
+        {
+          "required": [
+            "artifactLocation"
+          ]
+        }
+      ],
+      "description": "A physical location relevant to a result. Specifies a reference to a programming artifact together with a range of bytes or characters within that artifact.",
+      "properties": {
+        "address": {
+          "$ref": "#/definitions/address",
+          "description": "The address of the location."
+        },
+        "artifactLocation": {
+          "$ref": "#/definitions/artifactLocation",
+          "description": "The location of the artifact."
+        },
+        "contextRegion": {
+          "$ref": "#/definitions/region",
+          "description": "Specifies a portion of the artifact that encloses the region. Allows a viewer to display additional context around the region."
+        },
+        "properties": {
+          "$ref": "#/definitions/propertyBag",
+          "description": "Key/value pairs that provide additional information about the physical location."
+        },
+        "region": {
+          "$ref": "#/definitions/region",
+          "description": "Specifies a portion of the artifact."
+        }
+      },
+      "type": "object"
+    },
+    "propertyBag": {
+      "additionalProperties": true,
+      "description": "Key/value pairs that provide additional information about the object.",
+      "properties": {
+        "tags": {
+          "default": [],
+          "description": "A set of distinct strings that provide additional information.",
+          "items": {
+            "type": "string"
+          },
+          "minItems": 0,
+          "type": "array",
+          "uniqueItems": true
+        }
+      },
+      "type": "object"
+    },
+    "rectangle": {
+      "additionalProperties": false,
+      "description": "An area within an image.",
+      "properties": {
+        "bottom": {
+          "description": "The Y coordinate of the bottom edge of the rectangle, measured in the image's natural units.",
+          "type": "number"
+        },
+        "left": {
+          "description": "The X coordinate of the left edge of the rectangle, measured in the image's natural units.",
+          "type": "number"
+        },
+        "message": {
+          "$ref": "#/definitions/message",
+          "description": "A message relevant to the rectangle."
+        },
+        "properties": {
+          "$ref": "#/definitions/propertyBag",
+          "description": "Key/value pairs that provide additional information about the rectangle."
+        },
+        "right": {
+          "description": "The X coordinate of the right edge of the rectangle, measured in the image's natural units.",
+          "type": "number"
+        },
+        "top": {
+          "description": "The Y coordinate of the top edge of the rectangle, measured in the image's natural units.",
+          "type": "number"
+        }
+      },
+      "type": "object"
+    },
+    "region": {
+      "additionalProperties": false,
+      "description": "A region within an artifact where a result was detected.",
+      "properties": {
+        "byteLength": {
+          "description": "The length of the region in bytes.",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "byteOffset": {
+          "default": -1,
+          "description": "The zero-based offset from the beginning of the artifact of the first byte in the region.",
+          "minimum": -1,
+          "type": "integer"
+        },
+        "charLength": {
+          "description": "The length of the region in characters.",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "charOffset": {
+          "default": -1,
+          "description": "The zero-based offset from the beginning of the artifact of the first character in the region.",
+          "minimum": -1,
+          "type": "integer"
+        },
+        "endColumn": {
+          "description": "The column number of the character following the end of the region.",
+          "minimum": 1,
+          "type": "integer"
+        },
+        "endLine": {
+          "description": "The line number of the last character in the region.",
+          "minimum": 1,
+          "type": "integer"
+        },
+        "message": {
+          "$ref": "#/definitions/message",
+          "description": "A message relevant to the region."
+        },
+        "properties": {
+          "$ref": "#/definitions/propertyBag",
+          "description": "Key/value pairs that provide additional information about the region."
+        },
+        "snippet": {
+          "$ref": "#/definitions/artifactContent",
+          "description": "The portion of the artifact contents within the specified region."
+        },
+        "sourceLanguage": {
+          "description": "Specifies the source language, if any, of the portion of the artifact specified by the region object.",
+          "type": "string"
+        },
+        "startColumn": {
+          "description": "The column number of the first character in the region.",
+          "minimum": 1,
+          "type": "integer"
+        },
+        "startLine": {
+          "description": "The line number of the first character in the region.",
+          "minimum": 1,
+          "type": "integer"
+        }
+      },
+      "type": "object"
+    },
+    "replacement": {
+      "additionalProperties": false,
+      "description": "The replacement of a single region of an artifact.",
+      "properties": {
+        "deletedRegion": {
+          "$ref": "#/definitions/region",
+          "description": "The region of the artifact to delete."
+        },
+        "insertedContent": {
+          "$ref": "#/definitions/artifactContent",
+          "description": "The content to insert at the location specified by the 'deletedRegion' property."
+        },
+        "properties": {
+          "$ref": "#/definitions/propertyBag",
+          "description": "Key/value pairs that provide additional information about the replacement."
+        }
+      },
+      "required": [
+        "deletedRegion"
+      ],
+      "type": "object"
+    },
+    "reportingConfiguration": {
+      "additionalProperties": false,
+      "description": "Information about a rule or notification that can be configured at runtime.",
+      "properties": {
+        "enabled": {
+          "default": true,
+          "description": "Specifies whether the report may be produced during the scan.",
+          "type": "boolean"
+        },
+        "level": {
+          "default": "warning",
+          "description": "Specifies the failure level for the report.",
+          "enum": [
+            "none",
+            "note",
+            "warning",
+            "error"
+          ]
+        },
+        "parameters": {
+          "$ref": "#/definitions/propertyBag",
+          "description": "Contains configuration information specific to a report."
+        },
+        "properties": {
+          "$ref": "#/definitions/propertyBag",
+          "description": "Key/value pairs that provide additional information about the reporting configuration."
+        },
+        "rank": {
+          "default": -1,
+          "description": "Specifies the relative priority of the report. Used for analysis output only.",
+          "maximum": 100,
+          "minimum": -1,
+          "type": "number"
+        }
+      },
+      "type": "object"
+    },
+    "reportingDescriptor": {
+      "additionalProperties": false,
+      "description": "Metadata that describes a specific report produced by the tool, as part of the analysis it provides or its runtime reporting.",
+      "properties": {
+        "defaultConfiguration": {
+          "$ref": "#/definitions/reportingConfiguration",
+          "description": "Default reporting configuration information."
+        },
+        "deprecatedGuids": {
+          "description": "An array of unique identifies in the form of a GUID by which this report was known in some previous version of the analysis tool.",
+          "items": {
+            "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$",
+            "type": "string"
+          },
+          "minItems": 0,
+          "type": "array",
+          "uniqueItems": true
+        },
+        "deprecatedIds": {
+          "description": "An array of stable, opaque identifiers by which this report was known in some previous version of the analysis tool.",
+          "items": {
+            "type": "string"
+          },
+          "minItems": 0,
+          "type": "array",
+          "uniqueItems": true
+        },
+        "deprecatedNames": {
+          "description": "An array of readable identifiers by which this report was known in some previous version of the analysis tool.",
+          "items": {
+            "type": "string"
+          },
+          "minItems": 0,
+          "type": "array",
+          "uniqueItems": true
+        },
+        "fullDescription": {
+          "$ref": "#/definitions/multiformatMessageString",
+          "description": "A description of the report. Should, as far as possible, provide details sufficient to enable resolution of any problem indicated by the result."
+        },
+        "guid": {
+          "description": "A unique identifier for the reporting descriptor in the form of a GUID.",
+          "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$",
+          "type": "string"
+        },
+        "help": {
+          "$ref": "#/definitions/multiformatMessageString",
+          "description": "Provides the primary documentation for the report, useful when there is no online documentation."
+        },
+        "helpUri": {
+          "description": "A URI where the primary documentation for the report can be found.",
+          "format": "uri",
+          "type": "string"
+        },
+        "id": {
+          "description": "A stable, opaque identifier for the report.",
+          "type": "string"
+        },
+        "messageStrings": {
+          "additionalProperties": {
+            "$ref": "#/definitions/multiformatMessageString"
+          },
+          "description": "A set of name/value pairs with arbitrary names. Each value is a multiformatMessageString object, which holds message strings in plain text and (optionally) Markdown format. The strings can include placeholders, which can be used to construct a message in combination with an arbitrary number of additional string arguments.",
+          "type": "object"
+        },
+        "name": {
+          "description": "A report identifier that is understandable to an end user.",
+          "type": "string"
+        },
+        "properties": {
+          "$ref": "#/definitions/propertyBag",
+          "description": "Key/value pairs that provide additional information about the report."
+        },
+        "relationships": {
+          "default": [],
+          "description": "An array of objects that describe relationships between this reporting descriptor and others.",
+          "items": {
+            "$ref": "#/definitions/reportingDescriptorRelationship"
+          },
+          "minItems": 0,
+          "type": "array",
+          "uniqueItems": true
+        },
+        "shortDescription": {
+          "$ref": "#/definitions/multiformatMessageString",
+          "description": "A concise description of the report. Should be a single sentence that is understandable when visible space is limited to a single line of text."
+        }
+      },
+      "required": [
+        "id"
+      ],
+      "type": "object"
+    },
+    "reportingDescriptorReference": {
+      "additionalProperties": false,
+      "anyOf": [
+        {
+          "required": [
+            "index"
+          ]
+        },
+        {
+          "required": [
+            "guid"
+          ]
+        },
+        {
+          "required": [
+            "id"
+          ]
+        }
+      ],
+      "description": "Information about how to locate a relevant reporting descriptor.",
+      "properties": {
+        "guid": {
+          "description": "A guid that uniquely identifies the descriptor.",
+          "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$",
+          "type": "string"
+        },
+        "id": {
+          "description": "The id of the descriptor.",
+          "type": "string"
+        },
+        "index": {
+          "default": -1,
+          "description": "The index into an array of descriptors in toolComponent.ruleDescriptors, toolComponent.notificationDescriptors, or toolComponent.taxonomyDescriptors, depending on context.",
+          "minimum": -1,
+          "type": "integer"
+        },
+        "properties": {
+          "$ref": "#/definitions/propertyBag",
+          "description": "Key/value pairs that provide additional information about the reporting descriptor reference."
+        },
+        "toolComponent": {
+          "$ref": "#/definitions/toolComponentReference",
+          "description": "A reference used to locate the toolComponent associated with the descriptor."
+        }
+      },
+      "type": "object"
+    },
+    "reportingDescriptorRelationship": {
+      "additionalProperties": false,
+      "description": "Information about the relation of one reporting descriptor to another.",
+      "properties": {
+        "description": {
+          "$ref": "#/definitions/message",
+          "description": "A description of the reporting descriptor relationship."
+        },
+        "kinds": {
+          "default": [
+            "relevant"
+          ],
+          "description": "A set of distinct strings that categorize the relationship. Well-known kinds include 'canPrecede', 'canFollow', 'willPrecede', 'willFollow', 'superset', 'subset', 'equal', 'disjoint', 'relevant', and 'incomparable'.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "uniqueItems": true
+        },
+        "properties": {
+          "$ref": "#/definitions/propertyBag",
+          "description": "Key/value pairs that provide additional information about the reporting descriptor reference."
+        },
+        "target": {
+          "$ref": "#/definitions/reportingDescriptorReference",
+          "description": "A reference to the related reporting descriptor."
+        }
+      },
+      "required": [
+        "target"
+      ],
+      "type": "object"
+    },
+    "result": {
+      "additionalProperties": false,
+      "description": "A result produced by an analysis tool.",
+      "properties": {
+        "analysisTarget": {
+          "$ref": "#/definitions/artifactLocation",
+          "description": "Identifies the artifact that the analysis tool was instructed to scan. This need not be the same as the artifact where the result actually occurred."
+        },
+        "attachments": {
+          "default": [],
+          "description": "A set of artifacts relevant to the result.",
+          "items": {
+            "$ref": "#/definitions/attachment"
+          },
+          "minItems": 0,
+          "type": "array",
+          "uniqueItems": true
+        },
+        "baselineState": {
+          "description": "The state of a result relative to a baseline of a previous run.",
+          "enum": [
+            "new",
+            "unchanged",
+            "updated",
+            "absent"
+          ]
+        },
+        "codeFlows": {
+          "default": [],
+          "description": "An array of 'codeFlow' objects relevant to the result.",
+          "items": {
+            "$ref": "#/definitions/codeFlow"
+          },
+          "minItems": 0,
+          "type": "array",
+          "uniqueItems": false
+        },
+        "correlationGuid": {
+          "description": "A stable, unique identifier for the equivalence class of logically identical results to which this result belongs, in the form of a GUID.",
+          "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$",
+          "type": "string"
+        },
+        "fingerprints": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "A set of strings each of which individually defines a stable, unique identity for the result.",
+          "type": "object"
+        },
+        "fixes": {
+          "default": [],
+          "description": "An array of 'fix' objects, each of which represents a proposed fix to the problem indicated by the result.",
+          "items": {
+            "$ref": "#/definitions/fix"
+          },
+          "minItems": 0,
+          "type": "array",
+          "uniqueItems": true
+        },
+        "graphTraversals": {
+          "default": [],
+          "description": "An array of one or more unique 'graphTraversal' objects.",
+          "items": {
+            "$ref": "#/definitions/graphTraversal"
+          },
+          "minItems": 0,
+          "type": "array",
+          "uniqueItems": true
+        },
+        "graphs": {
+          "default": [],
+          "description": "An array of zero or more unique graph objects associated with the result.",
+          "items": {
+            "$ref": "#/definitions/graph"
+          },
+          "minItems": 0,
+          "type": "array",
+          "uniqueItems": true
+        },
+        "guid": {
+          "description": "A stable, unique identifier for the result in the form of a GUID.",
+          "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$",
+          "type": "string"
+        },
+        "hostedViewerUri": {
+          "description": "An absolute URI at which the result can be viewed.",
+          "format": "uri",
+          "type": "string"
+        },
+        "kind": {
+          "default": "fail",
+          "description": "A value that categorizes results by evaluation state.",
+          "enum": [
+            "notApplicable",
+            "pass",
+            "fail",
+            "review",
+            "open",
+            "informational"
+          ]
+        },
+        "level": {
+          "default": "warning",
+          "description": "A value specifying the severity level of the result.",
+          "enum": [
+            "none",
+            "note",
+            "warning",
+            "error"
+          ]
+        },
+        "locations": {
+          "default": [],
+          "description": "The set of locations where the result was detected. Specify only one location unless the problem indicated by the result can only be corrected by making a change at every specified location.",
+          "items": {
+            "$ref": "#/definitions/location"
+          },
+          "minItems": 0,
+          "type": "array",
+          "uniqueItems": false
+        },
+        "message": {
+          "$ref": "#/definitions/message",
+          "description": "A message that describes the result. The first sentence of the message only will be displayed when visible space is limited."
+        },
+        "occurrenceCount": {
+          "description": "A positive integer specifying the number of times this logically unique result was observed in this run.",
+          "minimum": 1,
+          "type": "integer"
+        },
+        "partialFingerprints": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "A set of strings that contribute to the stable, unique identity of the result.",
+          "type": "object"
+        },
+        "properties": {
+          "$ref": "#/definitions/propertyBag",
+          "description": "Key/value pairs that provide additional information about the result."
+        },
+        "provenance": {
+          "$ref": "#/definitions/resultProvenance",
+          "description": "Information about how and when the result was detected."
+        },
+        "rank": {
+          "default": -1,
+          "description": "A number representing the priority or importance of the result.",
+          "maximum": 100,
+          "minimum": -1,
+          "type": "number"
+        },
+        "relatedLocations": {
+          "default": [],
+          "description": "A set of locations relevant to this result.",
+          "items": {
+            "$ref": "#/definitions/location"
+          },
+          "minItems": 0,
+          "type": "array",
+          "uniqueItems": true
+        },
+        "rule": {
+          "$ref": "#/definitions/reportingDescriptorReference",
+          "description": "A reference used to locate the rule descriptor relevant to this result."
+        },
+        "ruleId": {
+          "description": "The stable, unique identifier of the rule, if any, to which this result is relevant.",
+          "type": "string"
+        },
+        "ruleIndex": {
+          "default": -1,
+          "description": "The index within the tool component rules array of the rule object associated with this result.",
+          "minimum": -1,
+          "type": "integer"
+        },
+        "stacks": {
+          "default": [],
+          "description": "An array of 'stack' objects relevant to the result.",
+          "items": {
+            "$ref": "#/definitions/stack"
+          },
+          "minItems": 0,
+          "type": "array",
+          "uniqueItems": true
+        },
+        "suppressions": {
+          "description": "A set of suppressions relevant to this result.",
+          "items": {
+            "$ref": "#/definitions/suppression"
+          },
+          "minItems": 0,
+          "type": "array",
+          "uniqueItems": true
+        },
+        "taxa": {
+          "default": [],
+          "description": "An array of references to taxonomy reporting descriptors that are applicable to the result.",
+          "items": {
+            "$ref": "#/definitions/reportingDescriptorReference"
+          },
+          "minItems": 0,
+          "type": "array",
+          "uniqueItems": true
+        },
+        "webRequest": {
+          "$ref": "#/definitions/webRequest",
+          "description": "A web request associated with this result."
+        },
+        "webResponse": {
+          "$ref": "#/definitions/webResponse",
+          "description": "A web response associated with this result."
+        },
+        "workItemUris": {
+          "description": "The URIs of the work items associated with this result.",
+          "items": {
+            "format": "uri",
+            "type": "string"
+          },
+          "minItems": 0,
+          "type": "array",
+          "uniqueItems": true
+        }
+      },
+      "required": [
+        "message"
+      ],
+      "type": "object"
+    },
+    "resultProvenance": {
+      "additionalProperties": false,
+      "description": "Contains information about how and when a result was detected.",
+      "properties": {
+        "conversionSources": {
+          "default": [],
+          "description": "An array of physicalLocation objects which specify the portions of an analysis tool's output that a converter transformed into the result.",
+          "items": {
+            "$ref": "#/definitions/physicalLocation"
+          },
+          "minItems": 0,
+          "type": "array",
+          "uniqueItems": true
+        },
+        "firstDetectionRunGuid": {
+          "description": "A GUID-valued string equal to the automationDetails.guid property of the run in which the result was first detected.",
+          "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$",
+          "type": "string"
+        },
+        "firstDetectionTimeUtc": {
+          "description": "The Coordinated Universal Time (UTC) date and time at which the result was first detected. See \"Date/time properties\" in the SARIF spec for the required format.",
+          "format": "date-time",
+          "type": "string"
+        },
+        "invocationIndex": {
+          "default": -1,
+          "description": "The index within the run.invocations array of the invocation object which describes the tool invocation that detected the result.",
+          "minimum": -1,
+          "type": "integer"
+        },
+        "lastDetectionRunGuid": {
+          "description": "A GUID-valued string equal to the automationDetails.guid property of the run in which the result was most recently detected.",
+          "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$",
+          "type": "string"
+        },
+        "lastDetectionTimeUtc": {
+          "description": "The Coordinated Universal Time (UTC) date and time at which the result was most recently detected. See \"Date/time properties\" in the SARIF spec for the required format.",
+          "format": "date-time",
+          "type": "string"
+        },
+        "properties": {
+          "$ref": "#/definitions/propertyBag",
+          "description": "Key/value pairs that provide additional information about the result."
+        }
+      },
+      "type": "object"
+    },
+    "run": {
+      "additionalProperties": false,
+      "description": "Describes a single run of an analysis tool, and contains the reported output of that run.",
+      "properties": {
+        "addresses": {
+          "default": [],
+          "description": "Addresses associated with this run instance, if any.",
+          "items": {
+            "$ref": "#/definitions/address"
+          },
+          "minItems": 0,
+          "type": "array",
+          "uniqueItems": false
+        },
+        "artifacts": {
+          "description": "An array of artifact objects relevant to the run.",
+          "items": {
+            "$ref": "#/definitions/artifact"
+          },
+          "minItems": 0,
+          "type": "array",
+          "uniqueItems": true
+        },
+        "automationDetails": {
+          "$ref": "#/definitions/runAutomationDetails",
+          "description": "Automation details that describe this run."
+        },
+        "baselineGuid": {
+          "description": "The 'guid' property of a previous SARIF 'run' that comprises the baseline that was used to compute result 'baselineState' properties for the run.",
+          "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$",
+          "type": "string"
+        },
+        "columnKind": {
+          "description": "Specifies the unit in which the tool measures columns.",
+          "enum": [
+            "utf16CodeUnits",
+            "unicodeCodePoints"
+          ]
+        },
+        "conversion": {
+          "$ref": "#/definitions/conversion",
+          "description": "A conversion object that describes how a converter transformed an analysis tool's native reporting format into the SARIF format."
+        },
+        "defaultEncoding": {
+          "description": "Specifies the default encoding for any artifact object that refers to a text file.",
+          "type": "string"
+        },
+        "defaultSourceLanguage": {
+          "description": "Specifies the default source language for any artifact object that refers to a text file that contains source code.",
+          "type": "string"
+        },
+        "externalPropertyFileReferences": {
+          "$ref": "#/definitions/externalPropertyFileReferences",
+          "description": "References to external property files that should be inlined with the content of a root log file."
+        },
+        "graphs": {
+          "default": [],
+          "description": "An array of zero or more unique graph objects associated with the run.",
+          "items": {
+            "$ref": "#/definitions/graph"
+          },
+          "minItems": 0,
+          "type": "array",
+          "uniqueItems": true
+        },
+        "invocations": {
+          "default": [],
+          "description": "Describes the invocation of the analysis tool.",
+          "items": {
+            "$ref": "#/definitions/invocation"
+          },
+          "minItems": 0,
+          "type": "array",
+          "uniqueItems": false
+        },
+        "language": {
+          "default": "en-US",
+          "description": "The language of the messages emitted into the log file during this run (expressed as an ISO 639-1 two-letter lowercase culture code) and an optional region (expressed as an ISO 3166-1 two-letter uppercase subculture code associated with a country or region). The casing is recommended but not required (in order for this data to conform to RFC5646).",
+          "pattern": "^[a-zA-Z]{2}|^[a-zA-Z]{2}-[a-zA-Z]{2}?$",
+          "type": "string"
+        },
+        "logicalLocations": {
+          "default": [],
+          "description": "An array of logical locations such as namespaces, types or functions.",
+          "items": {
+            "$ref": "#/definitions/logicalLocation"
+          },
+          "minItems": 0,
+          "type": "array",
+          "uniqueItems": true
+        },
+        "newlineSequences": {
+          "default": [
+            "\r\n",
+            "\n"
+          ],
+          "description": "An ordered list of character sequences that were treated as line breaks when computing region information for the run.",
+          "items": {
+            "type": "string"
+          },
+          "minItems": 1,
+          "type": "array",
+          "uniqueItems": true
+        },
+        "originalUriBaseIds": {
+          "additionalProperties": {
+            "$ref": "#/definitions/artifactLocation"
+          },
+          "description": "The artifact location specified by each uriBaseId symbol on the machine where the tool originally ran.",
+          "type": "object"
+        },
+        "policies": {
+          "default": [],
+          "description": "Contains configurations that may potentially override both reportingDescriptor.defaultConfiguration (the tool's default severities) and invocation.configurationOverrides (severities established at run-time from the command line).",
+          "items": {
+            "$ref": "#/definitions/toolComponent"
+          },
+          "minItems": 0,
+          "type": "array",
+          "uniqueItems": true
+        },
+        "properties": {
+          "$ref": "#/definitions/propertyBag",
+          "description": "Key/value pairs that provide additional information about the run."
+        },
+        "redactionTokens": {
+          "default": [],
+          "description": "An array of strings used to replace sensitive information in a redaction-aware property.",
+          "items": {
+            "type": "string"
+          },
+          "minItems": 0,
+          "type": "array",
+          "uniqueItems": true
+        },
+        "results": {
+          "description": "The set of results contained in an SARIF log. The results array can be omitted when a run is solely exporting rules metadata. It must be present (but may be empty) if a log file represents an actual scan.",
+          "items": {
+            "$ref": "#/definitions/result"
+          },
+          "minItems": 0,
+          "type": "array",
+          "uniqueItems": false
+        },
+        "runAggregates": {
+          "default": [],
+          "description": "Automation details that describe the aggregate of runs to which this run belongs.",
+          "items": {
+            "$ref": "#/definitions/runAutomationDetails"
+          },
+          "minItems": 0,
+          "type": "array",
+          "uniqueItems": true
+        },
+        "specialLocations": {
+          "$ref": "#/definitions/specialLocations",
+          "description": "A specialLocations object that defines locations of special significance to SARIF consumers."
+        },
+        "taxonomies": {
+          "default": [],
+          "description": "An array of toolComponent objects relevant to a taxonomy in which results are categorized.",
+          "items": {
+            "$ref": "#/definitions/toolComponent"
+          },
+          "minItems": 0,
+          "type": "array",
+          "uniqueItems": true
+        },
+        "threadFlowLocations": {
+          "default": [],
+          "description": "An array of threadFlowLocation objects cached at run level.",
+          "items": {
+            "$ref": "#/definitions/threadFlowLocation"
+          },
+          "minItems": 0,
+          "type": "array",
+          "uniqueItems": true
+        },
+        "tool": {
+          "$ref": "#/definitions/tool",
+          "description": "Information about the tool or tool pipeline that generated the results in this run. A run can only contain results produced by a single tool or tool pipeline. A run can aggregate results from multiple log files, as long as context around the tool run (tool command-line arguments and the like) is identical for all aggregated files."
+        },
+        "translations": {
+          "default": [],
+          "description": "The set of available translations of the localized data provided by the tool.",
+          "items": {
+            "$ref": "#/definitions/toolComponent"
+          },
+          "minItems": 0,
+          "type": "array",
+          "uniqueItems": true
+        },
+        "versionControlProvenance": {
+          "default": [],
+          "description": "Specifies the revision in version control of the artifacts that were scanned.",
+          "items": {
+            "$ref": "#/definitions/versionControlDetails"
+          },
+          "minItems": 0,
+          "type": "array",
+          "uniqueItems": true
+        },
+        "webRequests": {
+          "default": [],
+          "description": "An array of request objects cached at run level.",
+          "items": {
+            "$ref": "#/definitions/webRequest"
+          },
+          "minItems": 0,
+          "type": "array",
+          "uniqueItems": true
+        },
+        "webResponses": {
+          "default": [],
+          "description": "An array of response objects cached at run level.",
+          "items": {
+            "$ref": "#/definitions/webResponse"
+          },
+          "minItems": 0,
+          "type": "array",
+          "uniqueItems": true
+        }
+      },
+      "required": [
+        "tool"
+      ],
+      "type": "object"
+    },
+    "runAutomationDetails": {
+      "additionalProperties": false,
+      "description": "Information that describes a run's identity and role within an engineering system process.",
+      "properties": {
+        "correlationGuid": {
+          "description": "A stable, unique identifier for the equivalence class of runs to which this object's containing run object belongs in the form of a GUID.",
+          "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$",
+          "type": "string"
+        },
+        "description": {
+          "$ref": "#/definitions/message",
+          "description": "A description of the identity and role played within the engineering system by this object's containing run object."
+        },
+        "guid": {
+          "description": "A stable, unique identifier for this object's containing run object in the form of a GUID.",
+          "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$",
+          "type": "string"
+        },
+        "id": {
+          "description": "A hierarchical string that uniquely identifies this object's containing run object.",
+          "type": "string"
+        },
+        "properties": {
+          "$ref": "#/definitions/propertyBag",
+          "description": "Key/value pairs that provide additional information about the run automation details."
+        }
+      },
+      "type": "object"
+    },
+    "specialLocations": {
+      "additionalProperties": false,
+      "description": "Defines locations of special significance to SARIF consumers.",
+      "properties": {
+        "displayBase": {
+          "$ref": "#/definitions/artifactLocation",
+          "description": "Provides a suggestion to SARIF consumers to display file paths relative to the specified location."
+        },
+        "properties": {
+          "$ref": "#/definitions/propertyBag",
+          "description": "Key/value pairs that provide additional information about the special locations."
+        }
+      },
+      "type": "object"
+    },
+    "stack": {
+      "additionalProperties": false,
+      "description": "A call stack that is relevant to a result.",
+      "properties": {
+        "frames": {
+          "description": "An array of stack frames that represents a sequence of calls, rendered in reverse chronological order, that comprise the call stack.",
+          "items": {
+            "$ref": "#/definitions/stackFrame"
+          },
+          "minItems": 0,
+          "type": "array",
+          "uniqueItems": false
+        },
+        "message": {
+          "$ref": "#/definitions/message",
+          "description": "A message relevant to this call stack."
+        },
+        "properties": {
+          "$ref": "#/definitions/propertyBag",
+          "description": "Key/value pairs that provide additional information about the stack."
+        }
+      },
+      "required": [
+        "frames"
+      ],
+      "type": "object"
+    },
+    "stackFrame": {
+      "additionalProperties": false,
+      "description": "A function call within a stack trace.",
+      "properties": {
+        "location": {
+          "$ref": "#/definitions/location",
+          "description": "The location to which this stack frame refers."
+        },
+        "module": {
+          "description": "The name of the module that contains the code of this stack frame.",
+          "type": "string"
+        },
+        "parameters": {
+          "default": [],
+          "description": "The parameters of the call that is executing.",
+          "items": {
+            "default": [],
+            "type": "string"
+          },
+          "minItems": 0,
+          "type": "array",
+          "uniqueItems": false
+        },
+        "properties": {
+          "$ref": "#/definitions/propertyBag",
+          "description": "Key/value pairs that provide additional information about the stack frame."
+        },
+        "threadId": {
+          "description": "The thread identifier of the stack frame.",
+          "type": "integer"
+        }
+      },
+      "type": "object"
+    },
+    "suppression": {
+      "additionalProperties": false,
+      "description": "A suppression that is relevant to a result.",
+      "properties": {
+        "guid": {
+          "description": "A stable, unique identifier for the suppression in the form of a GUID.",
+          "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$",
+          "type": "string"
+        },
+        "justification": {
+          "description": "A string representing the justification for the suppression.",
+          "type": "string"
+        },
+        "kind": {
+          "description": "A string that indicates where the suppression is persisted.",
+          "enum": [
+            "inSource",
+            "external"
+          ]
+        },
+        "location": {
+          "$ref": "#/definitions/location",
+          "description": "Identifies the location associated with the suppression."
+        },
+        "properties": {
+          "$ref": "#/definitions/propertyBag",
+          "description": "Key/value pairs that provide additional information about the suppression."
+        },
+        "status": {
+          "description": "A string that indicates the review status of the suppression.",
+          "enum": [
+            "accepted",
+            "underReview",
+            "rejected"
+          ]
+        }
+      },
+      "required": [
+        "kind"
+      ],
+      "type": "object"
+    },
+    "threadFlow": {
+      "additionalProperties": false,
+      "description": "Describes a sequence of code locations that specify a path through a single thread of execution such as an operating system or fiber.",
+      "properties": {
+        "id": {
+          "description": "An string that uniquely identifies the threadFlow within the codeFlow in which it occurs.",
+          "type": "string"
+        },
+        "immutableState": {
+          "additionalProperties": {
+            "$ref": "#/definitions/multiformatMessageString"
+          },
+          "description": "Values of relevant expressions at the start of the thread flow that remain constant.",
+          "type": "object"
+        },
+        "initialState": {
+          "additionalProperties": {
+            "$ref": "#/definitions/multiformatMessageString"
+          },
+          "description": "Values of relevant expressions at the start of the thread flow that may change during thread flow execution.",
+          "type": "object"
+        },
+        "locations": {
+          "description": "A temporally ordered array of 'threadFlowLocation' objects, each of which describes a location visited by the tool while producing the result.",
+          "items": {
+            "$ref": "#/definitions/threadFlowLocation"
+          },
+          "minItems": 1,
+          "type": "array",
+          "uniqueItems": false
+        },
+        "message": {
+          "$ref": "#/definitions/message",
+          "description": "A message relevant to the thread flow."
+        },
+        "properties": {
+          "$ref": "#/definitions/propertyBag",
+          "description": "Key/value pairs that provide additional information about the thread flow."
+        }
+      },
+      "required": [
+        "locations"
+      ],
+      "type": "object"
+    },
+    "threadFlowLocation": {
+      "additionalProperties": false,
+      "description": "A location visited by an analysis tool while simulating or monitoring the execution of a program.",
+      "properties": {
+        "executionOrder": {
+          "default": -1,
+          "description": "An integer representing the temporal order in which execution reached this location.",
+          "minimum": -1,
+          "type": "integer"
+        },
+        "executionTimeUtc": {
+          "description": "The Coordinated Universal Time (UTC) date and time at which this location was executed.",
+          "format": "date-time",
+          "type": "string"
+        },
+        "importance": {
+          "default": "important",
+          "description": "Specifies the importance of this location in understanding the code flow in which it occurs. The order from most to least important is \"essential\", \"important\", \"unimportant\". Default: \"important\".",
+          "enum": [
+            "important",
+            "essential",
+            "unimportant"
+          ]
+        },
+        "index": {
+          "default": -1,
+          "description": "The index within the run threadFlowLocations array.",
+          "minimum": -1,
+          "type": "integer"
+        },
+        "kinds": {
+          "default": [],
+          "description": "A set of distinct strings that categorize the thread flow location. Well-known kinds include 'acquire', 'release', 'enter', 'exit', 'call', 'return', 'branch', 'implicit', 'false', 'true', 'caution', 'danger', 'unknown', 'unreachable', 'taint', 'function', 'handler', 'lock', 'memory', 'resource', 'scope' and 'value'.",
+          "items": {
+            "type": "string"
+          },
+          "minItems": 0,
+          "type": "array",
+          "uniqueItems": true
+        },
+        "location": {
+          "$ref": "#/definitions/location",
+          "description": "The code location."
+        },
+        "module": {
+          "description": "The name of the module that contains the code that is executing.",
+          "type": "string"
+        },
+        "nestingLevel": {
+          "description": "An integer representing a containment hierarchy within the thread flow.",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "properties": {
+          "$ref": "#/definitions/propertyBag",
+          "description": "Key/value pairs that provide additional information about the threadflow location."
+        },
+        "stack": {
+          "$ref": "#/definitions/stack",
+          "description": "The call stack leading to this location."
+        },
+        "state": {
+          "additionalProperties": {
+            "$ref": "#/definitions/multiformatMessageString"
+          },
+          "description": "A dictionary, each of whose keys specifies a variable or expression, the associated value of which represents the variable or expression value. For an annotation of kind 'continuation', for example, this dictionary might hold the current assumed values of a set of global variables.",
+          "type": "object"
+        },
+        "taxa": {
+          "default": [],
+          "description": "An array of references to rule or taxonomy reporting descriptors that are applicable to the thread flow location.",
+          "items": {
+            "$ref": "#/definitions/reportingDescriptorReference"
+          },
+          "minItems": 0,
+          "type": "array",
+          "uniqueItems": true
+        },
+        "webRequest": {
+          "$ref": "#/definitions/webRequest",
+          "description": "A web request associated with this thread flow location."
+        },
+        "webResponse": {
+          "$ref": "#/definitions/webResponse",
+          "description": "A web response associated with this thread flow location."
+        }
+      },
+      "type": "object"
+    },
+    "tool": {
+      "additionalProperties": false,
+      "description": "The analysis tool that was run.",
+      "properties": {
+        "driver": {
+          "$ref": "#/definitions/toolComponent",
+          "description": "The analysis tool that was run."
+        },
+        "extensions": {
+          "default": [],
+          "description": "Tool extensions that contributed to or reconfigured the analysis tool that was run.",
+          "items": {
+            "$ref": "#/definitions/toolComponent"
+          },
+          "minItems": 0,
+          "type": "array",
+          "uniqueItems": true
+        },
+        "properties": {
+          "$ref": "#/definitions/propertyBag",
+          "description": "Key/value pairs that provide additional information about the tool."
+        }
+      },
+      "required": [
+        "driver"
+      ],
+      "type": "object"
+    },
+    "toolComponent": {
+      "additionalProperties": false,
+      "description": "A component, such as a plug-in or the driver, of the analysis tool that was run.",
+      "properties": {
+        "associatedComponent": {
+          "$ref": "#/definitions/toolComponentReference",
+          "description": "The component which is strongly associated with this component. For a translation, this refers to the component which has been translated. For an extension, this is the driver that provides the extension's plugin model."
+        },
+        "contents": {
+          "default": [
+            "localizedData",
+            "nonLocalizedData"
+          ],
+          "description": "The kinds of data contained in this object.",
+          "items": {
+            "enum": [
+              "localizedData",
+              "nonLocalizedData"
+            ]
+          },
+          "type": "array",
+          "uniqueItems": true
+        },
+        "dottedQuadFileVersion": {
+          "description": "The binary version of the tool component's primary executable file expressed as four non-negative integers separated by a period (for operating systems that express file versions in this way).",
+          "pattern": "[0-9]+(\\.[0-9]+){3}",
+          "type": "string"
+        },
+        "downloadUri": {
+          "description": "The absolute URI from which the tool component can be downloaded.",
+          "format": "uri",
+          "type": "string"
+        },
+        "fullDescription": {
+          "$ref": "#/definitions/multiformatMessageString",
+          "description": "A comprehensive description of the tool component."
+        },
+        "fullName": {
+          "description": "The name of the tool component along with its version and any other useful identifying information, such as its locale.",
+          "type": "string"
+        },
+        "globalMessageStrings": {
+          "additionalProperties": {
+            "$ref": "#/definitions/multiformatMessageString"
+          },
+          "description": "A dictionary, each of whose keys is a resource identifier and each of whose values is a multiformatMessageString object, which holds message strings in plain text and (optionally) Markdown format. The strings can include placeholders, which can be used to construct a message in combination with an arbitrary number of additional string arguments.",
+          "type": "object"
+        },
+        "guid": {
+          "description": "A unique identifier for the tool component in the form of a GUID.",
+          "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$",
+          "type": "string"
+        },
+        "informationUri": {
+          "description": "The absolute URI at which information about this version of the tool component can be found.",
+          "format": "uri",
+          "type": "string"
+        },
+        "isComprehensive": {
+          "default": false,
+          "description": "Specifies whether this object contains a complete definition of the localizable and/or non-localizable data for this component, as opposed to including only data that is relevant to the results persisted to this log file.",
+          "type": "boolean"
+        },
+        "language": {
+          "default": "en-US",
+          "description": "The language of the messages emitted into the log file during this run (expressed as an ISO 639-1 two-letter lowercase language code) and an optional region (expressed as an ISO 3166-1 two-letter uppercase subculture code associated with a country or region). The casing is recommended but not required (in order for this data to conform to RFC5646).",
+          "pattern": "^[a-zA-Z]{2}|^[a-zA-Z]{2}-[a-zA-Z]{2}?$",
+          "type": "string"
+        },
+        "localizedDataSemanticVersion": {
+          "description": "The semantic version of the localized strings defined in this component; maintained by components that provide translations.",
+          "type": "string"
+        },
+        "locations": {
+          "default": [],
+          "description": "An array of the artifactLocation objects associated with the tool component.",
+          "items": {
+            "$ref": "#/definitions/artifactLocation"
+          },
+          "minItems": 0,
+          "type": "array"
+        },
+        "minimumRequiredLocalizedDataSemanticVersion": {
+          "description": "The minimum value of localizedDataSemanticVersion required in translations consumed by this component; used by components that consume translations.",
+          "type": "string"
+        },
+        "name": {
+          "description": "The name of the tool component.",
+          "type": "string"
+        },
+        "notifications": {
+          "default": [],
+          "description": "An array of reportingDescriptor objects relevant to the notifications related to the configuration and runtime execution of the tool component.",
+          "items": {
+            "$ref": "#/definitions/reportingDescriptor"
+          },
+          "minItems": 0,
+          "type": "array",
+          "uniqueItems": true
+        },
+        "organization": {
+          "description": "The organization or company that produced the tool component.",
+          "type": "string"
+        },
+        "product": {
+          "description": "A product suite to which the tool component belongs.",
+          "type": "string"
+        },
+        "productSuite": {
+          "description": "A localizable string containing the name of the suite of products to which the tool component belongs.",
+          "type": "string"
+        },
+        "properties": {
+          "$ref": "#/definitions/propertyBag",
+          "description": "Key/value pairs that provide additional information about the tool component."
+        },
+        "releaseDateUtc": {
+          "description": "A string specifying the UTC date (and optionally, the time) of the component's release.",
+          "type": "string"
+        },
+        "rules": {
+          "default": [],
+          "description": "An array of reportingDescriptor objects relevant to the analysis performed by the tool component.",
+          "items": {
+            "$ref": "#/definitions/reportingDescriptor"
+          },
+          "minItems": 0,
+          "type": "array",
+          "uniqueItems": true
+        },
+        "semanticVersion": {
+          "description": "The tool component version in the format specified by Semantic Versioning 2.0.",
+          "type": "string"
+        },
+        "shortDescription": {
+          "$ref": "#/definitions/multiformatMessageString",
+          "description": "A brief description of the tool component."
+        },
+        "supportedTaxonomies": {
+          "default": [],
+          "description": "An array of toolComponentReference objects to declare the taxonomies supported by the tool component.",
+          "items": {
+            "$ref": "#/definitions/toolComponentReference"
+          },
+          "minItems": 0,
+          "type": "array",
+          "uniqueItems": true
+        },
+        "taxa": {
+          "default": [],
+          "description": "An array of reportingDescriptor objects relevant to the definitions of both standalone and tool-defined taxonomies.",
+          "items": {
+            "$ref": "#/definitions/reportingDescriptor"
+          },
+          "minItems": 0,
+          "type": "array",
+          "uniqueItems": true
+        },
+        "translationMetadata": {
+          "$ref": "#/definitions/translationMetadata",
+          "description": "Translation metadata, required for a translation, not populated by other component types."
+        },
+        "version": {
+          "description": "The tool component version, in whatever format the component natively provides.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "type": "object"
+    },
+    "toolComponentReference": {
+      "additionalProperties": false,
+      "description": "Identifies a particular toolComponent object, either the driver or an extension.",
+      "properties": {
+        "guid": {
+          "description": "The 'guid' property of the referenced toolComponent.",
+          "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$",
+          "type": "string"
+        },
+        "index": {
+          "default": -1,
+          "description": "An index into the referenced toolComponent in tool.extensions.",
+          "minimum": -1,
+          "type": "integer"
+        },
+        "name": {
+          "description": "The 'name' property of the referenced toolComponent.",
+          "type": "string"
+        },
+        "properties": {
+          "$ref": "#/definitions/propertyBag",
+          "description": "Key/value pairs that provide additional information about the toolComponentReference."
+        }
+      },
+      "type": "object"
+    },
+    "translationMetadata": {
+      "additionalProperties": false,
+      "description": "Provides additional metadata related to translation.",
+      "properties": {
+        "downloadUri": {
+          "description": "The absolute URI from which the translation metadata can be downloaded.",
+          "format": "uri",
+          "type": "string"
+        },
+        "fullDescription": {
+          "$ref": "#/definitions/multiformatMessageString",
+          "description": "A comprehensive description of the translation metadata."
+        },
+        "fullName": {
+          "description": "The full name associated with the translation metadata.",
+          "type": "string"
+        },
+        "informationUri": {
+          "description": "The absolute URI from which information related to the translation metadata can be downloaded.",
+          "format": "uri",
+          "type": "string"
+        },
+        "name": {
+          "description": "The name associated with the translation metadata.",
+          "type": "string"
+        },
+        "properties": {
+          "$ref": "#/definitions/propertyBag",
+          "description": "Key/value pairs that provide additional information about the translation metadata."
+        },
+        "shortDescription": {
+          "$ref": "#/definitions/multiformatMessageString",
+          "description": "A brief description of the translation metadata."
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "type": "object"
+    },
+    "versionControlDetails": {
+      "additionalProperties": false,
+      "description": "Specifies the information necessary to retrieve a desired revision from a version control system.",
+      "properties": {
+        "asOfTimeUtc": {
+          "description": "A Coordinated Universal Time (UTC) date and time that can be used to synchronize an enlistment to the state of the repository at that time.",
+          "format": "date-time",
+          "type": "string"
+        },
+        "branch": {
+          "description": "The name of a branch containing the revision.",
+          "type": "string"
+        },
+        "mappedTo": {
+          "$ref": "#/definitions/artifactLocation",
+          "description": "The location in the local file system to which the root of the repository was mapped at the time of the analysis."
+        },
+        "properties": {
+          "$ref": "#/definitions/propertyBag",
+          "description": "Key/value pairs that provide additional information about the version control details."
+        },
+        "repositoryUri": {
+          "description": "The absolute URI of the repository.",
+          "format": "uri",
+          "type": "string"
+        },
+        "revisionId": {
+          "description": "A string that uniquely and permanently identifies the revision within the repository.",
+          "type": "string"
+        },
+        "revisionTag": {
+          "description": "A tag that has been applied to the revision.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "repositoryUri"
+      ],
+      "type": "object"
+    },
+    "webRequest": {
+      "additionalProperties": false,
+      "description": "Describes an HTTP request.",
+      "properties": {
+        "body": {
+          "$ref": "#/definitions/artifactContent",
+          "description": "The body of the request."
+        },
+        "headers": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "The request headers.",
+          "type": "object"
+        },
+        "index": {
+          "default": -1,
+          "description": "The index within the run.webRequests array of the request object associated with this result.",
+          "minimum": -1,
+          "type": "integer"
+        },
+        "method": {
+          "description": "The HTTP method. Well-known values are 'GET', 'PUT', 'POST', 'DELETE', 'PATCH', 'HEAD', 'OPTIONS', 'TRACE', 'CONNECT'.",
+          "type": "string"
+        },
+        "parameters": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "The request parameters.",
+          "type": "object"
+        },
+        "properties": {
+          "$ref": "#/definitions/propertyBag",
+          "description": "Key/value pairs that provide additional information about the request."
+        },
+        "protocol": {
+          "description": "The request protocol. Example: 'http'.",
+          "type": "string"
+        },
+        "target": {
+          "description": "The target of the request.",
+          "type": "string"
+        },
+        "version": {
+          "description": "The request version. Example: '1.1'.",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "webResponse": {
+      "additionalProperties": false,
+      "description": "Describes the response to an HTTP request.",
+      "properties": {
+        "body": {
+          "$ref": "#/definitions/artifactContent",
+          "description": "The body of the response."
+        },
+        "headers": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "The response headers.",
+          "type": "object"
+        },
+        "index": {
+          "default": -1,
+          "description": "The index within the run.webResponses array of the response object associated with this result.",
+          "minimum": -1,
+          "type": "integer"
+        },
+        "noResponseReceived": {
+          "default": false,
+          "description": "Specifies whether a response was received from the server.",
+          "type": "boolean"
+        },
+        "properties": {
+          "$ref": "#/definitions/propertyBag",
+          "description": "Key/value pairs that provide additional information about the response."
+        },
+        "protocol": {
+          "description": "The response protocol. Example: 'http'.",
+          "type": "string"
+        },
+        "reasonPhrase": {
+          "description": "The response reason. Example: 'Not found'.",
+          "type": "string"
+        },
+        "statusCode": {
+          "description": "The response status code. Example: 451.",
+          "type": "integer"
+        },
+        "version": {
+          "description": "The response version. Example: '1.1'.",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    }
+  },
+  "description": "Static Analysis Results Format (SARIF) Version 2.1.0 JSON Schema: a standard format for the output of static analysis tools.",
+  "properties": {
+    "$schema": {
+      "description": "The URI of the JSON schema corresponding to the version.",
+      "format": "uri",
+      "type": "string"
+    },
+    "inlineExternalProperties": {
+      "description": "References to external property files that share data between runs.",
+      "items": {
+        "$ref": "#/definitions/externalProperties"
+      },
+      "minItems": 0,
+      "type": "array",
+      "uniqueItems": true
+    },
+    "properties": {
+      "$ref": "#/definitions/propertyBag",
+      "description": "Key/value pairs that provide additional information about the log file."
+    },
+    "runs": {
+      "description": "The set of runs contained in this log file.",
+      "items": {
+        "$ref": "#/definitions/run"
+      },
+      "minItems": 0,
+      "type": "array",
+      "uniqueItems": false
+    },
+    "version": {
+      "description": "The SARIF format version of this log file.",
+      "enum": [
+        "2.1.0"
+      ]
+    }
+  },
+  "required": [
+    "version",
+    "runs"
+  ],
+  "title": "Static Analysis Results Format (SARIF) Version 2.1.0 JSON Schema",
+  "type": "object"
+}

--- a/src/mcp_migrate/cli.py
+++ b/src/mcp_migrate/cli.py
@@ -14,6 +14,7 @@ from rich.table import Table
 
 from . import __version__
 from .fixers import all_fixers
+from . import sarif as sarif_mod
 from .grade import badge_url, letter, score
 from .languages import DISPLAY, PARTIAL, SUPPORTED, describe, primary, survey
 from .rules import all_rules
@@ -159,6 +160,20 @@ def _print_language_hint(console, counts) -> None:
         )
 
 
+def _output_format(args) -> str:
+    """Resolve `--format` and the older `--json` into one answer.
+
+    `--json` predates this and is depended on by anyone who scripted
+    against it, so it stays and means `--format json`. Keeping it as an
+    alias rather than a second, independently-settable boolean is what
+    stops the two from ever disagreeing.
+    """
+    fmt = getattr(args, "format", None)
+    if fmt:
+        return fmt
+    return "json" if getattr(args, "json", False) else "text"
+
+
 def _finding_dict(f, rules) -> dict:
     d = {
         "rule": f.rule_id,
@@ -222,7 +237,23 @@ def cmd_check(args) -> int:
     reason = unscannable_reason(root, project, counts, include_tests=args.include_tests)
     sdk_info = detect_sdk(root)
 
-    if args.json:
+    if _output_format(args) == "sarif":
+        # Emitted for every outcome, including the ungraded one: code
+        # scanning wants a run even when it is empty, or it cannot tell
+        # "checked, nothing found" from "never ran" and leaves resolved
+        # alerts open forever.
+        print(json.dumps(
+            sarif_mod.build(findings, rules, root, version=__version__, spec=SPEC),
+            indent=2,
+        ))
+        if sdk_info.is_sdk:
+            return EXIT_OK
+        if reason:
+            return _exit_for(findings, rules) if _checked_something(project) \
+                else EXIT_UNSCANNABLE
+        return _exit_for(findings, rules)
+
+    if _output_format(args) == "json":
         if sdk_info.is_sdk:
             print(json.dumps({
                 "tool": "mcp-migrate",
@@ -713,7 +744,15 @@ def main(argv=None) -> int:
 
     p_check = sub.add_parser("check", help="check a project")
     p_check.add_argument("path", nargs="?", default=".")
-    p_check.add_argument("--json", action="store_true")
+    p_check.add_argument(
+        "--format", choices=("text", "json", "sarif"),
+        help="output format (default: text). sarif is SARIF 2.1.0, for "
+             "GitHub code scanning.",
+    )
+    p_check.add_argument(
+        "--json", action="store_true",
+        help="alias for --format json, kept for compatibility",
+    )
     p_check.add_argument(
         "--include-tests", action="store_true",
         help="also scan tests/, fixtures/, examples/, docs/, and test_*.py files "

--- a/src/mcp_migrate/sarif.py
+++ b/src/mcp_migrate/sarif.py
@@ -1,0 +1,173 @@
+"""SARIF 2.1.0 output.
+
+`--json` emits a shape of our own design, which is fine for a script and
+useless to everything else. SARIF is what GitHub code scanning speaks, and
+speaking it is what turns a finding from a line in a CI log into an
+annotation on the diff, an entry in the Security tab, and a thing that
+gets tracked across commits rather than re-read every time.
+
+This is a pure output format. No rule sees it, no scanner changes; it is a
+projection of the same findings `--json` already carries.
+
+Two decisions worth stating rather than burying, both raised in #182:
+
+**`deprecated` maps to `warning`.** `breaking` -> `error` and `advisory`
+-> `note` are forced. `deprecated` could go either way, and the choice
+decides whether a deprecation blocks a pull request by default, because
+code scanning's default gate fails on `error` alone. The spec gives
+deprecated features at least twelve months, so a deprecation is
+categorically "you have time, but start" -- exactly `warning`. Mapping it
+to `error` would make every server using Roots or Sampling unmergeable
+today over a change that does not break until next year, and the
+predictable response to that is switching the whole integration off.
+
+**Absolute severity, not the grade.** SARIF carries per-result levels and
+no overall score. That is a better fit than it looks: the grade is a
+weighted judgement about a project, while a SARIF run is a set of
+locations. Nothing here reports A-F, and `check` remains where a grade
+comes from.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+SARIF_VERSION = "2.1.0"
+SCHEMA = "https://json.schemastore.org/sarif-2.1.0.json"
+
+INFORMATION_URI = "https://github.com/dheerajjha/mcp-migrate"
+
+# severity -> SARIF level. See the module docstring for why `deprecated`
+# is `warning` and not `error`.
+LEVEL = {
+    "breaking": "error",
+    "deprecated": "warning",
+    "advisory": "note",
+}
+DEFAULT_LEVEL = "warning"
+
+
+def _uri(path, root: Path) -> str:
+    """A repo-relative, forward-slashed URI for a finding's file.
+
+    Code scanning matches results to the diff by path, so an absolute path
+    from the scanning machine matches nothing and the annotations silently
+    never appear. Relative-to-repo-root is the only form that works, and
+    the separator has to be `/` on every platform.
+    """
+    if path is None:
+        return ""
+    p = Path(path)
+    try:
+        p = p.resolve().relative_to(root.resolve())
+    except (ValueError, OSError):
+        # Outside the scanned root, or unresolvable. Fall back to whatever
+        # we were given rather than dropping the location entirely -- a
+        # result with an imperfect path is still a result.
+        pass
+    return p.as_posix()
+
+
+def _rule_descriptor(rule) -> dict:
+    descriptor = {
+        "id": rule.id,
+        "name": rule.id,
+        "shortDescription": {"text": rule.title},
+        "defaultConfiguration": {"level": LEVEL.get(rule.severity, DEFAULT_LEVEL)},
+        "properties": {
+            # `tags` is what code scanning renders as filters, and the
+            # severity is the tag people actually want to filter on.
+            "tags": ["mcp", rule.severity],
+            "mcp-migrate.severity": rule.severity,
+        },
+    }
+    if rule.fix:
+        # fullDescription is the remediation text in the Security tab --
+        # `fix` is written as imperative advice, which is exactly right.
+        descriptor["fullDescription"] = {"text": rule.fix}
+        descriptor["help"] = {"text": rule.fix, "markdown": rule.fix}
+    if rule.spec_ref:
+        uri = _spec_uri(rule.spec_ref)
+        if uri:
+            descriptor["helpUri"] = uri
+        else:
+            # A spec_ref that is prose rather than a link still belongs in
+            # the output; helpUri must be a URI or consumers reject the
+            # document, so it rides in properties instead.
+            descriptor["properties"]["mcp-migrate.spec"] = rule.spec_ref
+    return descriptor
+
+
+def _spec_uri(spec_ref: str) -> str:
+    """Pull the URL out of a `spec_ref`, which is sometimes prose plus a link.
+
+    e.g. "SEP-2567 https://github.com/..." -> the URL. Rules whose
+    spec_ref is pure prose ("Roots, Sampling and Logging deprecated")
+    yield nothing, and the caller keeps the text as a property.
+    """
+    for token in str(spec_ref).split():
+        if token.startswith(("http://", "https://")):
+            return token.rstrip(".,)")
+    return ""
+
+
+def build(findings, rules, root: Path, *, version: str, spec: str) -> dict:
+    """The SARIF log for one `check` run.
+
+    `rules` is the full rule registry, not just the ones that fired: SARIF
+    wants the driver to declare every rule it can report, so a consumer
+    can tell "this rule ran and found nothing" from "this rule does not
+    exist". That distinction is the whole reason code scanning can close a
+    resolved alert instead of leaving it open forever.
+    """
+    ordered = [rules[rule_id] for rule_id in sorted(rules)]
+    index_of = {rule.id: i for i, rule in enumerate(ordered)}
+
+    results = []
+    for f in findings:
+        rule = rules[f.rule_id]
+        result = {
+            "ruleId": f.rule_id,
+            "ruleIndex": index_of[f.rule_id],
+            "level": LEVEL.get(rule.severity, DEFAULT_LEVEL),
+            "message": {"text": f.message},
+        }
+
+        uri = _uri(f.path, root)
+        if uri:
+            location = {
+                "physicalLocation": {
+                    "artifactLocation": {"uri": uri, "uriBaseId": "%SRCROOT%"},
+                }
+            }
+            if f.line:
+                # SARIF regions are 1-based, same as our line numbers.
+                location["physicalLocation"]["region"] = {"startLine": f.line}
+            result["locations"] = [location]
+        else:
+            # Project-level findings (R010 asks a question about the whole
+            # tree) have no file. SARIF allows an empty locations array and
+            # consumers render it against the repository root; omitting the
+            # key entirely makes some consumers drop the result.
+            result["locations"] = []
+
+        results.append(result)
+
+    return {
+        "$schema": SCHEMA,
+        "version": SARIF_VERSION,
+        "runs": [{
+            "tool": {
+                "driver": {
+                    "name": "mcp-migrate",
+                    "version": version,
+                    "semanticVersion": version,
+                    "informationUri": INFORMATION_URI,
+                    "rules": [_rule_descriptor(r) for r in ordered],
+                    "properties": {"mcp-migrate.spec": spec},
+                }
+            },
+            "originalUriBaseIds": {"%SRCROOT%": {"uri": root.resolve().as_uri() + "/"}},
+            "results": results,
+            "columnKind": "utf16CodeUnits",
+        }],
+    }

--- a/tests/test_sarif.py
+++ b/tests/test_sarif.py
@@ -1,0 +1,200 @@
+"""SARIF 2.1.0 output, validated against the vendored official schema.
+
+The schema is checked in rather than fetched. A test that pulls a schema
+over the network is a flake waiting to happen, and this one runs on four
+Python versions per push.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import jsonschema
+import pytest
+
+from mcp_migrate import __version__
+from mcp_migrate.cli import main
+from mcp_migrate.rules import all_rules
+from mcp_migrate.sarif import LEVEL, _spec_uri
+
+ROOT = Path(__file__).resolve().parent.parent
+SCHEMA = json.loads(
+    (ROOT / "schemas" / "sarif-2.1.0.schema.json").read_text(encoding="utf-8")
+)
+FIXTURES = ROOT / "tests" / "fixtures"
+
+
+def run_sarif(capsys, root: Path, *extra) -> tuple[dict, int]:
+    exit_code = main(["check", str(root), "--format", "sarif", *extra])
+    doc = json.loads(capsys.readouterr().out)
+    jsonschema.validate(doc, SCHEMA)
+    return doc, exit_code
+
+
+def only_run(doc: dict) -> dict:
+    assert len(doc["runs"]) == 1
+    return doc["runs"][0]
+
+
+# --- the schema contract -------------------------------------------------
+
+@pytest.mark.parametrize("fixture", ["clean_server", "legacy_server"])
+def test_output_validates_against_the_official_schema(capsys, fixture):
+    doc, _ = run_sarif(capsys, FIXTURES / fixture)
+    assert doc["version"] == "2.1.0"
+
+
+def test_an_empty_run_is_still_emitted(capsys):
+    # Code scanning needs a run even when nothing was found, or it cannot
+    # tell "checked, clean" from "never ran" -- and then it leaves already
+    # resolved alerts open forever.
+    doc, exit_code = run_sarif(capsys, FIXTURES / "clean_server")
+    run = only_run(doc)
+    assert run["results"] == []
+    assert run["tool"]["driver"]["rules"], "the driver must still declare its rules"
+    assert exit_code == 0
+
+
+def test_the_driver_declares_every_rule_not_just_the_ones_that_fired(capsys):
+    doc, _ = run_sarif(capsys, FIXTURES / "legacy_server")
+    declared = {r["id"] for r in only_run(doc)["tool"]["driver"]["rules"]}
+    assert declared == {r.id for r in all_rules()}
+
+
+def test_driver_metadata(capsys):
+    driver = only_run(run_sarif(capsys, FIXTURES / "legacy_server")[0])["tool"]["driver"]
+    assert driver["name"] == "mcp-migrate"
+    assert driver["version"] == __version__
+    assert driver["informationUri"].startswith("https://")
+
+
+# --- severity mapping ----------------------------------------------------
+
+@pytest.mark.parametrize("severity,level", [
+    ("breaking", "error"),
+    ("deprecated", "warning"),
+    ("advisory", "note"),
+])
+def test_severity_maps_to_the_documented_level(severity, level):
+    assert LEVEL[severity] == level
+
+
+def test_deprecated_does_not_block_a_pull_request_by_default(capsys):
+    # Code scanning's default gate fails on `error` alone. The spec gives
+    # deprecated features 12+ months, so mapping them to `error` would
+    # make every server using Roots or Sampling unmergeable today over a
+    # change that does not break until next year.
+    doc, _ = run_sarif(capsys, FIXTURES / "legacy_server")
+    run = only_run(doc)
+    by_id = {r["id"]: r for r in run["tool"]["driver"]["rules"]}
+
+    for result in run["results"]:
+        rule = by_id[result["ruleId"]]
+        severity = rule["properties"]["mcp-migrate.severity"]
+        if severity == "deprecated":
+            assert result["level"] == "warning"
+
+
+def test_every_result_level_matches_its_rule_severity(capsys):
+    doc, _ = run_sarif(capsys, FIXTURES / "legacy_server")
+    run = only_run(doc)
+    rules = {r.id: r for r in all_rules()}
+    for result in run["results"]:
+        assert result["level"] == LEVEL[rules[result["ruleId"]].severity]
+
+
+def test_rule_index_points_at_the_right_descriptor(capsys):
+    # ruleIndex is an offset into the driver's rules array. Off by one and
+    # every finding is attributed to the wrong rule, with no error.
+    doc, _ = run_sarif(capsys, FIXTURES / "legacy_server")
+    run = only_run(doc)
+    declared = run["tool"]["driver"]["rules"]
+    for result in run["results"]:
+        assert declared[result["ruleIndex"]]["id"] == result["ruleId"]
+
+
+# --- locations -----------------------------------------------------------
+
+def test_paths_are_relative_to_the_scanned_root(capsys):
+    # Code scanning matches results to the diff by path. An absolute path
+    # from the scanning machine matches nothing, and the annotations
+    # silently never appear.
+    doc, _ = run_sarif(capsys, FIXTURES / "legacy_server")
+    for result in only_run(doc)["results"]:
+        for loc in result["locations"]:
+            uri = loc["physicalLocation"]["artifactLocation"]["uri"]
+            assert not uri.startswith("/"), uri
+            assert ".." not in uri, uri
+            assert "\\" not in uri, "URIs are forward-slashed on every platform"
+
+
+def test_line_numbers_survive(capsys):
+    doc, _ = run_sarif(capsys, FIXTURES / "legacy_server")
+    regions = [
+        loc["physicalLocation"].get("region")
+        for result in only_run(doc)["results"]
+        for loc in result["locations"]
+    ]
+    assert any(r and r["startLine"] > 0 for r in regions)
+
+
+def test_a_project_level_finding_still_produces_a_result(capsys):
+    # R010 asks a question about the whole tree and has no file. Dropping
+    # such findings would silently lose them; SARIF allows an empty
+    # locations array.
+    doc, _ = run_sarif(capsys, FIXTURES / "legacy_server")
+    run = only_run(doc)
+    assert all("locations" in r for r in run["results"])
+
+
+# --- helpUri -------------------------------------------------------------
+
+def test_spec_refs_that_are_urls_become_help_uris(capsys):
+    doc, _ = run_sarif(capsys, FIXTURES / "legacy_server")
+    declared = only_run(doc)["tool"]["driver"]["rules"]
+    assert any("helpUri" in r for r in declared)
+    for rule in declared:
+        if "helpUri" in rule:
+            assert rule["helpUri"].startswith("http")
+
+
+def test_a_prose_spec_ref_does_not_become_an_invalid_help_uri():
+    # "Roots, Sampling and Logging deprecated" is not a URI; emitting it
+    # as one makes consumers reject the whole document.
+    assert _spec_uri("Roots, Sampling and Logging deprecated") == ""
+    assert _spec_uri("SEP-2567 https://github.com/x/y/pull/1") == "https://github.com/x/y/pull/1"
+
+
+# --- CLI surface ---------------------------------------------------------
+
+def test_json_remains_an_alias_and_does_not_emit_sarif(capsys):
+    # --json predates --format and is depended on; it must keep working
+    # and must keep its own shape.
+    main(["check", str(FIXTURES / "legacy_server"), "--json"])
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["tool"] == "mcp-migrate"
+    assert "runs" not in payload
+
+
+def test_format_json_matches_the_json_flag(capsys):
+    main(["check", str(FIXTURES / "legacy_server"), "--json"])
+    from_flag = capsys.readouterr().out
+    main(["check", str(FIXTURES / "legacy_server"), "--format", "json"])
+    from_format = capsys.readouterr().out
+    assert from_flag == from_format
+
+
+def test_exit_codes_are_unchanged_by_the_format(capsys):
+    # The format decides what is printed, never what is returned.
+    for fixture, expected in (("clean_server", 0), ("legacy_server", 1)):
+        sarif_code = main(["check", str(FIXTURES / fixture), "--format", "sarif"])
+        capsys.readouterr()
+        json_code = main(["check", str(FIXTURES / fixture), "--json"])
+        capsys.readouterr()
+        assert sarif_code == json_code == expected, fixture
+
+
+def test_an_unreadable_tree_still_emits_a_valid_document(capsys, tmp_path):
+    doc, exit_code = run_sarif(capsys, tmp_path)
+    assert only_run(doc)["results"] == []
+    assert exit_code == 2


### PR DESCRIPTION
Fixes #182.

```bash
mcp-migrate check . --format sarif > mcp-migrate.sarif
```

Pure output format — no rule or scanner changes, just a projection of the findings `--json` already carries into the shape code scanning speaks. Findings annotate the diff and land in the Security tab instead of scrolling past in a log.

## The two decisions you asked to be made, not guessed

### `deprecated` → `warning`, not `error`

`breaking` → `error` and `advisory` → `note` are forced. This one is the real choice, because **code scanning's default gate fails on `error` alone** — so the mapping decides whether a deprecation blocks a pull request.

The spec gives deprecated features at least twelve months. That makes a deprecation categorically *"you have time, but start"*, which is what `warning` means. Mapping it to `error` would make every server using Roots or Sampling unmergeable **today** over a change that doesn't break until next year — and the predictable response to that is switching the whole integration off, at which point it catches nothing.

### `--format {text,json,sarif}`, with `--json` as an alias

Taking your suggestion over a second boolean. `--json` predates this and is depended on, so it stays — and both resolve through one function, which is what stops them from ever disagreeing. There's a test asserting `--json` and `--format json` produce byte-identical output.

## Three details that decide whether this actually works

**Paths are relative to the scanned root, forward-slashed.** Code scanning matches results to the diff by path. An absolute path from the scanning machine matches nothing and the annotations silently never appear — no error, just no annotations.

**The driver declares all 21 rules, not only the ones that fired.** That's how a consumer distinguishes "this rule ran and found nothing" from "this rule doesn't exist", which is what lets code scanning **close** a resolved alert rather than leaving it open forever. Same reason a clean run still emits a full document with an empty `results` array.

**A prose `spec_ref` doesn't become a `helpUri`.** Rules like R007 have `spec_ref = "Roots, Sampling and Logging deprecated"` — not a URI. Emitting it as one makes consumers reject the entire document, so it rides in `properties` instead and only real URLs become `helpUri`.

Project-level findings (R010 asks a question about the whole tree and has no file) keep an empty `locations` array rather than being dropped.

## Schema validation

The SARIF 2.1.0 schema is vendored at `schemas/sarif-2.1.0.schema.json` and validated against in CI — as you asked, a test that fetches a schema over the network is a flake waiting to happen, and this one runs on four Python versions per push. `jsonschema` was already a dev dependency for `check-json.schema.json`, so no new dep.

Real output on `tests/fixtures/legacy_server`: 53 results, 21 declared rules, levels `error`/`warning`/`note`, validates clean.

## Tests (20)

Schema validation on clean and legacy fixtures · the severity mapping · every result's level matching its rule's severity · `ruleIndex` pointing at the right descriptor (off by one and every finding is attributed to the wrong rule, with no error anywhere) · relative paths · line numbers · project-level findings surviving · prose `spec_ref`s not becoming URIs · `--json` unchanged · `--json` ≡ `--format json` · and exit codes unchanged by format — the format decides what is printed, never what is returned.

Full suite: **479 passed**.

---

This is the piece #100 needs to be worth shipping: an Action that can only print to a log is a fraction as useful as one that files findings into the Security tab. Happy to follow up with the Action itself now that #98 and #85 have both landed.