### PR TITLE
feat: inline suppression, auditable by construction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,48 @@ All notable changes to this project are documented here.
 
 ## [Unreleased]
 
+### Added
+
+- **Inline suppression: `# mcp-migrate: ignore[R001] -- reason`.** Silence a
+  single wrong finding without switching a rule off for the whole project.
+  Both comment syntaxes, so it reads naturally in Python and TypeScript.
+  ([#180](https://github.com/dheerajjha/mcp-migrate/issues/180))
+
+  A suppressed finding does not count against the grade. A suppression that
+  still costs you the grade is not a suppression — the only move left would
+  be to stop running the tool. That makes the grade partly self-reported, so
+  it is auditable by construction rather than by convention:
+
+  - the rule id is required; a blanket `ignore` would also silence rules that
+    do not exist yet, and nobody revisits it
+  - a reason is expected, and directives without one are reported
+  - the suppression count prints on every run, never behind a flag
+  - `--show-suppressions` lists each one with its file, rule and reason
+  - directives that matched nothing are reported, so stale ones cannot
+    quietly accumulate
+
+  Malformed directives are reported rather than dropped: someone wrote it
+  believing it worked, and the finding it was meant to silence is about to
+  appear anyway.
+
+  `R005`, `R015` and `R016` report at most one finding per file, so
+  suppressing their line silences those rules for that whole file. Documented
+  in the README; every other rule is genuinely per-line.
+
+### Changed
+
+- **`check --json` gained two required keys, `suppressed` and
+  `unused_suppressions`.** Both are always present, empty array included. A
+  consumer validating against the 0.2.0 schema will reject 0.3.0 output until
+  it is updated; `schemas/check-json.schema.json` is the executable contract.
+  Findings that were suppressed are absent from `findings` and from `counts`,
+  so a consumer that sums `counts` still gets a total matching `findings`.
+
+  `unused_suppressions` carries one entry per rule id (`rule`, `path`, `line`,
+  `reason`). It is in the JSON and not only on the console because stale
+  suppressions accumulate in CI, and CI is exactly the consumer that reads
+  `--json` and never sees a console line.
+
 ### Fixed
 
 - **R004 no longer fires on a wire method name that returns no tools.**

--- a/README.md
+++ b/README.md
@@ -60,13 +60,17 @@ every finding).
 
 `--json` emits one JSON object with these always-present top-level keys:
 `tool`, `version`, `spec`, `path`, `scannable`, `languages`, `grade`,
-`score`, `files_scanned`, `counts`, and `findings`.
+`score`, `files_scanned`, `counts`, `findings`, and `suppressed`.
 
 Conditional keys:
 
 - `is_sdk` and `sdk_reason` only when the tree is a protocol SDK. In that case `grade` and `score` are `null`.
 - `reason` only when `scannable` is `false`. In that case `grade` and `score` are `null`.
 - `grade` and `score` are also `null` when a tree was read but is not gradable, for example TypeScript-only trees.
+
+`suppressed` holds findings silenced by an inline `mcp-migrate: ignore[R0NN]`
+comment; they are excluded from `findings`, from `counts`, and from the grade,
+and each carries the `reason` from its comment.
 
 Each finding always has `rule`, `severity`, `path`, `line`, and `message`.
 `path` and `line` may be `null` for project-level findings. `fix` is present
@@ -77,6 +81,36 @@ The executable contract is
 this shape may change in a breaking way; such changes are documented under
 Changed in [CHANGELOG.md](CHANGELOG.md), so consumers should pin a version
 and watch that section.
+
+### Suppressing a finding
+
+This tool has open false-positive classes and says so above. When a finding
+is wrong, or the code is deliberate and not changing, silence that one line
+rather than the whole rule:
+
+```python
+mcp_session_id = req.headers["X-Sid"]  # mcp-migrate: ignore[R001] -- proxy shim, not MCP session state
+```
+
+```ts
+const mcpSessionId = req.headers["x-sid"];  // mcp-migrate: ignore[R001] -- proxy shim
+```
+
+The rule id is required — a blanket `ignore` would also silence rules that
+don't exist yet, and nobody ever revisits it. A reason after `--` is expected;
+`check` reports directives that lack one.
+
+A suppressed finding **doesn't count against the grade** — a suppression that
+still costs you the grade isn't one, and the only move left would be to stop
+running the tool. That does make the grade partly self-reported, so three
+things keep it auditable:
+
+- the count is always printed, never behind a flag
+- `--show-suppressions` lists every one with its file, rule and reason
+- `check` reports suppressions that matched nothing, so stale ones don't
+  quietly accumulate
+
+`--json` carries them under `suppressed`, each with its `reason`.
 
 Exit codes, so it drops straight into CI:
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,8 @@ every finding).
 
 `--json` emits one JSON object with these always-present top-level keys:
 `tool`, `version`, `spec`, `path`, `scannable`, `languages`, `grade`,
-`score`, `files_scanned`, `counts`, `findings`, and `suppressed`.
+`score`, `files_scanned`, `counts`, `findings`, `suppressed`, and
+`unused_suppressions`.
 
 Conditional keys:
 
@@ -71,6 +72,12 @@ Conditional keys:
 `suppressed` holds findings silenced by an inline `mcp-migrate: ignore[R0NN]`
 comment; they are excluded from `findings`, from `counts`, and from the grade,
 and each carries the `reason` from its comment.
+
+`unused_suppressions` holds directives that matched no finding — either it was
+fixed or the code moved. Each entry has `rule`, `path`, `line`, and `reason`,
+one per rule id. It is always present, empty array included: stale suppressions
+accumulate in CI, and CI is the consumer that reads `--json` and never sees a
+console line.
 
 Each finding always has `rule`, `severity`, `path`, `line`, and `message`.
 `path` and `line` may be `null` for project-level findings. `fix` is present
@@ -110,7 +117,18 @@ things keep it auditable:
 - `check` reports suppressions that matched nothing, so stale ones don't
   quietly accumulate
 
-`--json` carries them under `suppressed`, each with its `reason`.
+`--json` carries them under `suppressed`, each with its `reason`, and the stale
+ones under `unused_suppressions`.
+
+**One caveat, because "line-scoped" promises slightly less than it delivers for
+three rules.** `R005`, `R015` and `R016` ask a question about a *file* — does
+this file declare capabilities without `extensions`, does it build a JSON-RPC
+result without `resultType`, does it implement a list/read handler without cache
+metadata — so each reports at most one finding per file, on the first line that
+matches. Suppressing that line therefore silences the rule **for the whole
+file**, not just that line. Every other rule reports each occurrence
+separately, and there suppression really is per line. If you suppress one of
+these three, you are accepting the rule's verdict on that file.
 
 Exit codes, so it drops straight into CI:
 

--- a/schemas/check-json.schema.json
+++ b/schemas/check-json.schema.json
@@ -15,7 +15,8 @@
     "files_scanned",
     "counts",
     "findings",
-    "suppressed"
+    "suppressed",
+    "unused_suppressions"
   ],
   "additionalProperties": false,
   "properties": {
@@ -180,6 +181,36 @@
           },
           "fix": {
             "type": "string"
+          },
+          "reason": {
+            "type": "string",
+            "description": "the text after `--` in the ignore comment; empty if none was given"
+          }
+        }
+      }
+    },
+    "unused_suppressions": {
+      "type": "array",
+      "description": "inline `mcp-migrate: ignore[R0NN]` directives that matched no finding. Either the finding was fixed or the code moved; both are worth knowing, because stale suppressions accumulate in CI and nothing else in the pipeline can see them. One entry per rule id: a directive naming several rules that matched nothing has every one of them stale.",
+      "items": {
+        "type": "object",
+        "required": [
+          "rule",
+          "path",
+          "line",
+          "reason"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "rule": {
+            "type": "string",
+            "pattern": "^R[0-9]{3}$"
+          },
+          "path": {
+            "type": "string"
+          },
+          "line": {
+            "type": "integer"
           },
           "reason": {
             "type": "string",

--- a/schemas/check-json.schema.json
+++ b/schemas/check-json.schema.json
@@ -14,7 +14,8 @@
     "score",
     "files_scanned",
     "counts",
-    "findings"
+    "findings",
+    "suppressed"
   ],
   "additionalProperties": false,
   "properties": {
@@ -50,11 +51,17 @@
       }
     },
     "grade": {
-      "type": ["string", "null"],
+      "type": [
+        "string",
+        "null"
+      ],
       "pattern": "^[A-F]$"
     },
     "score": {
-      "type": ["integer", "null"],
+      "type": [
+        "integer",
+        "null"
+      ],
       "minimum": 0,
       "maximum": 100
     },
@@ -64,7 +71,11 @@
     },
     "counts": {
       "type": "object",
-      "required": ["breaking", "deprecated", "advisory"],
+      "required": [
+        "breaking",
+        "deprecated",
+        "advisory"
+      ],
       "additionalProperties": false,
       "properties": {
         "breaking": {
@@ -85,7 +96,13 @@
       "type": "array",
       "items": {
         "type": "object",
-        "required": ["rule", "severity", "path", "line", "message"],
+        "required": [
+          "rule",
+          "severity",
+          "path",
+          "line",
+          "message"
+        ],
         "additionalProperties": false,
         "properties": {
           "rule": {
@@ -93,19 +110,80 @@
             "pattern": "^R[0-9]{3}$"
           },
           "severity": {
-            "enum": ["breaking", "deprecated", "advisory"]
+            "enum": [
+              "breaking",
+              "deprecated",
+              "advisory"
+            ]
           },
           "path": {
-            "type": ["string", "null"]
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "line": {
-            "type": ["integer", "null"]
+            "type": [
+              "integer",
+              "null"
+            ]
           },
           "message": {
             "type": "string"
           },
           "fix": {
             "type": "string"
+          }
+        }
+      }
+    },
+    "suppressed": {
+      "type": "array",
+      "description": "findings silenced by an inline `mcp-migrate: ignore[R0NN]` comment. Not counted in `counts`, and not counted against the grade.",
+      "items": {
+        "type": "object",
+        "required": [
+          "rule",
+          "severity",
+          "path",
+          "line",
+          "message",
+          "reason"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "rule": {
+            "type": "string",
+            "pattern": "^R[0-9]{3}$"
+          },
+          "severity": {
+            "enum": [
+              "breaking",
+              "deprecated",
+              "advisory"
+            ]
+          },
+          "path": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "line": {
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "message": {
+            "type": "string"
+          },
+          "fix": {
+            "type": "string"
+          },
+          "reason": {
+            "type": "string",
+            "description": "the text after `--` in the ignore comment; empty if none was given"
           }
         }
       }
@@ -119,10 +197,14 @@
             "const": false
           }
         },
-        "required": ["scannable"]
+        "required": [
+          "scannable"
+        ]
       },
       "then": {
-        "required": ["reason"],
+        "required": [
+          "reason"
+        ],
         "properties": {
           "grade": {
             "const": null
@@ -140,10 +222,14 @@
             "const": true
           }
         },
-        "required": ["is_sdk"]
+        "required": [
+          "is_sdk"
+        ]
       },
       "then": {
-        "required": ["sdk_reason"],
+        "required": [
+          "sdk_reason"
+        ],
         "properties": {
           "grade": {
             "const": null

--- a/src/mcp_migrate/cli.py
+++ b/src/mcp_migrate/cli.py
@@ -215,6 +215,32 @@ def _suppressed_dict(f, rules, result) -> dict:
     return d
 
 
+def _unused_suppression_dicts(result) -> list[dict]:
+    """Suppressions that matched nothing, one entry per rule id.
+
+    The text output already reports these, but stale suppressions
+    accumulate in CI, and CI is precisely the consumer that reads `--json`
+    and never sees a console line. Leaving them text-only inverts the
+    design: a team could carry a dozen suppressions that stopped matching
+    months ago with nothing in their pipeline able to notice.
+
+    One entry per rule id, rather than one entry with a `rules` array, so
+    the shape matches `suppressed` and a consumer can read both with the
+    same code path. A directive that matched nothing has every rule id in
+    it stale, so expanding them loses no information.
+    """
+    return [
+        {
+            "rule": rule_id,
+            "path": str(s.path),
+            "line": s.line,
+            "reason": s.reason,
+        }
+        for s in suppress_mod.unused(result.suppressions)
+        for rule_id in s.rule_ids
+    ]
+
+
 def _finding_dict(f, rules) -> dict:
     d = {
         "rule": f.rule_id,
@@ -338,6 +364,7 @@ def cmd_check(args) -> int:
                 "counts": _severity_counts(findings, rules),
                 "findings": [_finding_dict(f, rules) for f in findings],
                 "suppressed": [_suppressed_dict(f, rules, result) for f in result.suppressed],
+                "unused_suppressions": _unused_suppression_dicts(result),
             }, indent=2))
             return EXIT_OK
         if reason:
@@ -358,6 +385,7 @@ def cmd_check(args) -> int:
                 "counts": _severity_counts(findings, rules),
                 "findings": [_finding_dict(f, rules) for f in findings],
                 "suppressed": [_suppressed_dict(f, rules, result) for f in result.suppressed],
+                "unused_suppressions": _unused_suppression_dicts(result),
             }, indent=2))
             return _exit_for(findings, rules) if _checked_something(project) \
                 else EXIT_UNSCANNABLE
@@ -374,6 +402,7 @@ def cmd_check(args) -> int:
             "counts": _severity_counts(findings, rules),
             "findings": [_finding_dict(f, rules) for f in findings],
             "suppressed": [_suppressed_dict(f, rules, result) for f in result.suppressed],
+            "unused_suppressions": _unused_suppression_dicts(result),
         }, indent=2))
         return _exit_for(findings, rules)
 

--- a/src/mcp_migrate/cli.py
+++ b/src/mcp_migrate/cli.py
@@ -7,12 +7,14 @@ import itertools
 import json
 import sys
 from collections import Counter
+from dataclasses import dataclass
 from pathlib import Path
 
 from rich.console import Console
 from rich.table import Table
 
 from . import __version__
+from . import suppress as suppress_mod
 from .fixers import all_fixers
 from .grade import badge_url, letter, score
 from .languages import DISPLAY, PARTIAL, SUPPORTED, describe, primary, survey
@@ -44,7 +46,26 @@ GRADE_ISSUE_URL = "https://github.com/dheerajjha/mcp-migrate/issues/172"
 JS_ISSUE_URL = "https://github.com/dheerajjha/mcp-migrate/issues/149"
 
 
-def run_check(root: Path, *, include_tests: bool = False):
+@dataclass
+class CheckResult:
+    """Everything one `check` produced.
+
+    `findings` excludes suppressed ones -- they are in `suppressed`, and
+    the score is computed without them. See suppress.apply for why, and
+    for what keeps that honest.
+    """
+
+    project: object
+    rules: dict
+    findings: list
+    value: int
+    grade: str
+    suppressed: list
+    suppressions: list
+    suppression_problems: list
+
+
+def run_check_detailed(root: Path, *, include_tests: bool = False) -> "CheckResult":
     project = load_project(root, include_tests=include_tests)
     rules = {r.id: r for r in all_rules()}
     findings = []
@@ -61,8 +82,27 @@ def run_check(root: Path, *, include_tests: bool = False):
             if view.files:
                 findings.extend(rule.check(view))
     findings.sort(key=lambda f: (SEV_ORDER.get(rules[f.rule_id].severity, 9), f.rule_id))
+
+    suppressions, problems = suppress_mod.collect(project)
+    findings, suppressed = suppress_mod.apply(findings, suppressions)
+
     value = score(findings, rules)
-    return project, rules, findings, value, letter(value)
+    return CheckResult(
+        project=project, rules=rules, findings=findings, value=value,
+        grade=letter(value), suppressed=suppressed,
+        suppressions=suppressions, suppression_problems=problems,
+    )
+
+
+def run_check(root: Path, *, include_tests: bool = False):
+    """The 5-tuple every existing caller unpacks.
+
+    `run_check_detailed` is the full result; this stays because a lot of
+    code -- tests included -- unpacks exactly five values, and widening a
+    tuple is the kind of change that breaks callers silently.
+    """
+    r = run_check_detailed(root, include_tests=include_tests)
+    return r.project, r.rules, r.findings, r.value, r.grade
 
 
 def _partial_coverage() -> tuple[int, int]:
@@ -159,6 +199,22 @@ def _print_language_hint(console, counts) -> None:
         )
 
 
+def _suppressed_dict(f, rules, result) -> dict:
+    """A suppressed finding, with the reason that suppressed it.
+
+    The reason is the point. A suppression list without reasons is a list
+    of findings somebody made disappear.
+    """
+    d = _finding_dict(f, rules)
+    reason = ""
+    for s in result.suppressions:
+        if str(s.path) == str(f.path) and s.line == f.line and f.rule_id.upper() in s.rule_ids:
+            reason = s.reason
+            break
+    d["reason"] = reason
+    return d
+
+
 def _finding_dict(f, rules) -> dict:
     d = {
         "rule": f.rule_id,
@@ -207,6 +263,47 @@ def _checked_something(project) -> bool:
     return any(f.language in SUPPORTED or f.language in PARTIAL for f in project.files)
 
 
+def _report_suppressions(console, result, *, show: bool) -> None:
+    """Say how many findings were suppressed -- always, not behind a flag.
+
+    A suppressed finding is one the grade no longer pays for, so the count
+    is part of reading the grade honestly. Hiding it behind a flag would
+    make this a way to quietly improve a score, which is exactly the
+    stale-claim problem #101 removed from the badge.
+    """
+    for problem in result.suppression_problems:
+        console.print(
+            f"[yellow]suppression ignored[/yellow]  {problem.location()}  {problem.message}"
+        )
+
+    stale = suppress_mod.unused(result.suppressions)
+    for s in stale:
+        console.print(
+            f"[dim]unused suppression[/dim]    {s.location()}  "
+            f"ignore[{', '.join(s.rule_ids)}] matched nothing -- fixed, or the code moved?"
+        )
+
+    if not result.suppressed:
+        return
+
+    console.print()
+    console.print(
+        f"[yellow]{len(result.suppressed)} finding(s) suppressed[/yellow] by inline "
+        f"`mcp-migrate: ignore` comments, and not counted against the grade."
+    )
+    if show:
+        for f in result.suppressed:
+            reason = next(
+                (s.reason for s in result.suppressions
+                 if str(s.path) == str(f.path) and s.line == f.line
+                 and f.rule_id.upper() in s.rule_ids),
+                "",
+            )
+            console.print(f"  [dim]{f.rule_id}  {f.location()}[/dim]  {reason or '(no reason given)'}")
+    else:
+        console.print("[dim]Run with --show-suppressions to see each one and its reason.[/dim]")
+
+
 def cmd_check(args) -> int:
     console = Console()
     root = Path(args.path).resolve()
@@ -217,7 +314,9 @@ def cmd_check(args) -> int:
         console.print(f"[bold red]No such path:[/bold red] {root}")
         return EXIT_UNSCANNABLE
 
-    project, rules, findings, value, grade = run_check(root, include_tests=args.include_tests)
+    result = run_check_detailed(root, include_tests=args.include_tests)
+    project, rules, findings = result.project, result.rules, result.findings
+    value, grade = result.value, result.grade
     counts = survey(root)
     reason = unscannable_reason(root, project, counts, include_tests=args.include_tests)
     sdk_info = detect_sdk(root)
@@ -238,6 +337,7 @@ def cmd_check(args) -> int:
                 "files_scanned": len(project.files),
                 "counts": _severity_counts(findings, rules),
                 "findings": [_finding_dict(f, rules) for f in findings],
+                "suppressed": [_suppressed_dict(f, rules, result) for f in result.suppressed],
             }, indent=2))
             return EXIT_OK
         if reason:
@@ -257,6 +357,7 @@ def cmd_check(args) -> int:
                 # doesn't get is a grade.
                 "counts": _severity_counts(findings, rules),
                 "findings": [_finding_dict(f, rules) for f in findings],
+                "suppressed": [_suppressed_dict(f, rules, result) for f in result.suppressed],
             }, indent=2))
             return _exit_for(findings, rules) if _checked_something(project) \
                 else EXIT_UNSCANNABLE
@@ -272,6 +373,7 @@ def cmd_check(args) -> int:
             "files_scanned": len(project.files),
             "counts": _severity_counts(findings, rules),
             "findings": [_finding_dict(f, rules) for f in findings],
+            "suppressed": [_suppressed_dict(f, rules, result) for f in result.suppressed],
         }, indent=2))
         return _exit_for(findings, rules)
 
@@ -378,6 +480,8 @@ def cmd_check(args) -> int:
         console.print()
         return _exit_for(findings, rules) if _checked_something(project) \
             else EXIT_UNSCANNABLE
+
+    _report_suppressions(console, result, show=args.show_suppressions)
 
     n_python = sum(1 for f in project.files if f.language == "python")
     console.print(f"[dim]{n_python} Python files, {len(rules)} rules, spec {SPEC}[/dim]")
@@ -714,6 +818,10 @@ def main(argv=None) -> int:
     p_check = sub.add_parser("check", help="check a project")
     p_check.add_argument("path", nargs="?", default=".")
     p_check.add_argument("--json", action="store_true")
+    p_check.add_argument(
+        "--show-suppressions", action="store_true",
+        help="list every inline `mcp-migrate: ignore` suppression and its reason",
+    )
     p_check.add_argument(
         "--include-tests", action="store_true",
         help="also scan tests/, fixtures/, examples/, docs/, and test_*.py files "

--- a/src/mcp_migrate/suppress.py
+++ b/src/mcp_migrate/suppress.py
@@ -1,0 +1,202 @@
+"""Inline suppression: `# mcp-migrate: ignore[R001] -- reason`.
+
+This tool ships with open false-positive classes and says so in its own
+README -- *"Treat a finding as a prompt to look, not as a verdict."* That
+is honest, and until now it was also unworkable in CI, where a breaking
+finding exits 1 and a user with one wrong finding had two options: switch
+the rule off for the whole project, or stop running the tool.
+
+There is also the legitimate case, which no amount of rule tuning fixes:
+code that genuinely reads the way a rule matches, on purpose, and is not
+going to change.
+
+Four things this deliberately does *not* allow, each because the sloppy
+version rots:
+
+**No blanket ignores.** The rule id is required. `# mcp-migrate: ignore`
+with no id silences whatever happens to be on that line today, including
+findings from rules written next year, and nobody ever revisits it.
+
+**No silent suppressions.** Every run reports how many findings were
+suppressed, and `--show-suppressions` lists each one with its reason.
+Suppression that cannot be audited is just a deleted finding with extra
+steps, and this tool's whole posture is that a claim nobody can check is
+worse than no claim.
+
+**A reason is required.** Same argument one level down: `ignore[R001]`
+with no explanation is unreviewable six months later, when the person who
+wrote it has left and nobody dares remove it.
+
+**Unused suppressions are reported.** A suppression that no longer
+matches anything is either a fixed bug or a moved line, and both are
+worth knowing -- otherwise they accumulate forever and the next reader
+cannot tell which are load-bearing.
+
+On the design question the issue raised -- *does a suppressed finding
+still count against the grade?* -- see `apply()`.
+"""
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+# `# mcp-migrate: ignore[R001] -- proxy shim, not MCP session state`
+# `// mcp-migrate: ignore[R001, R006] -- deliberate`
+#
+# Both comment syntaxes, since the same rules read Python and TypeScript.
+# The separator before the reason is `--` or `:` so it reads naturally in
+# either language without fighting the `//` prefix.
+DIRECTIVE_RX = re.compile(
+    r"(?:#|//)\s*mcp-migrate:\s*ignore\s*"
+    r"\[(?P<rules>[^\]]*)\]"
+    r"(?:\s*(?:--|:)\s*(?P<reason>.*?))?\s*$",
+    re.IGNORECASE,
+)
+
+# The same thing written without the rule list. Matched only so it can be
+# reported as an error -- silently ignoring a directive someone believed
+# was working is the worst outcome available here, because they will think
+# the finding is suppressed and it will not be.
+BARE_RX = re.compile(r"(?:#|//)\s*mcp-migrate:\s*ignore\s*(?![\[\w])", re.IGNORECASE)
+
+RULE_ID_RX = re.compile(r"^R\d{3}$", re.IGNORECASE)
+
+
+@dataclass
+class Suppression:
+    path: Path
+    line: int
+    rule_ids: tuple[str, ...]
+    reason: str
+    used: bool = False
+
+    def location(self) -> str:
+        return f"{self.path}:{self.line}"
+
+
+@dataclass
+class Problem:
+    """A malformed directive. Reported, never silently dropped."""
+
+    path: Path
+    line: int
+    message: str
+
+    def location(self) -> str:
+        return f"{self.path}:{self.line}"
+
+
+def parse_file(path: Path, text: str) -> tuple[list[Suppression], list[Problem]]:
+    suppressions: list[Suppression] = []
+    problems: list[Problem] = []
+
+    for i, line in enumerate(text.splitlines(), start=1):
+        m = DIRECTIVE_RX.search(line)
+        if not m:
+            if BARE_RX.search(line):
+                problems.append(Problem(
+                    path, i,
+                    "`mcp-migrate: ignore` needs a rule id, e.g. `ignore[R001]`. "
+                    "A blanket ignore would also silence rules that do not exist yet.",
+                ))
+            continue
+
+        raw_ids = [r.strip() for r in m.group("rules").replace(",", " ").split()]
+        rule_ids = tuple(r.upper() for r in raw_ids if RULE_ID_RX.match(r))
+        bad = [r for r in raw_ids if not RULE_ID_RX.match(r)]
+
+        if bad:
+            problems.append(Problem(
+                path, i, f"not a rule id: {', '.join(repr(b) for b in bad)}",
+            ))
+        if not rule_ids:
+            problems.append(Problem(path, i, "no valid rule id in the ignore directive"))
+            continue
+
+        reason = (m.group("reason") or "").strip()
+        if not reason:
+            problems.append(Problem(
+                path, i,
+                f"`ignore[{', '.join(rule_ids)}]` has no reason. Add one after `--`; "
+                "an unexplained suppression is unreviewable later.",
+            ))
+
+        suppressions.append(Suppression(path, i, rule_ids, reason))
+
+    return suppressions, problems
+
+
+def collect(project) -> tuple[list[Suppression], list[Problem]]:
+    """Every directive in the project, plus every malformed one."""
+    suppressions: list[Suppression] = []
+    problems: list[Problem] = []
+    for f in project.files:
+        s, p = parse_file(f.path, f.text)
+        suppressions.extend(s)
+        problems.extend(p)
+    return suppressions, problems
+
+
+def _index(suppressions: list[Suppression]) -> dict:
+    index: dict = {}
+    for s in suppressions:
+        index.setdefault((str(s.path), s.line), []).append(s)
+    return index
+
+
+def apply(findings, suppressions: list[Suppression]):
+    """Split findings into (kept, suppressed), marking suppressions used.
+
+    **The grade question.** A suppressed finding does not reach the
+    scorer, because a suppression that still costs you the grade is not a
+    suppression -- the user's only remaining move would be to stop running
+    the tool, which is the outcome this feature exists to prevent.
+
+    The cost is real and worth naming: the grade becomes partly
+    self-reported. Three things keep that honest rather than hiding it,
+    all of them at the caller:
+
+      * the count is always printed, never conditional on a flag
+      * `--show-suppressions` lists every one with its file, rule and
+        reason, so a reviewer can audit the lot in one command
+      * a suppression must name its rule and carry a reason, so the audit
+        is actually readable
+
+    Which is the same standard the badge work (#101) applied to a stale
+    grade: the claim can be wrong, but it cannot be quietly wrong.
+
+    Project-level findings (no line) are never suppressed. There is no
+    line to attach a comment to, and letting them be silenced from an
+    arbitrary line elsewhere would be a blanket ignore wearing a
+    disguise.
+    """
+    index = _index(suppressions)
+    kept, suppressed = [], []
+
+    for f in findings:
+        if f.path is None or f.line is None:
+            kept.append(f)
+            continue
+        matches = [
+            s for s in index.get((str(f.path), f.line), [])
+            if f.rule_id.upper() in s.rule_ids
+        ]
+        if matches:
+            for s in matches:
+                s.used = True
+            suppressed.append(f)
+        else:
+            kept.append(f)
+
+    return kept, suppressed
+
+
+def unused(suppressions: list[Suppression]) -> list[Suppression]:
+    """Suppressions that matched nothing.
+
+    Either the finding was fixed or the code moved. Both are worth
+    knowing: unused suppressions accumulate silently, and once there are
+    enough of them nobody can tell which are still load-bearing.
+    """
+    return [s for s in suppressions if not s.used]

--- a/tests/test_suppress.py
+++ b/tests/test_suppress.py
@@ -212,6 +212,50 @@ def test_suppressed_findings_are_not_in_findings_or_counts(tmp_path, capsys):
     assert sum(payload["counts"].values()) == len(payload["findings"])
 
 
+def test_unused_suppressions_reach_json_not_just_the_console(tmp_path, capsys):
+    # The audit story has to work for the consumer that cannot read the
+    # console. Stale suppressions accumulate in CI, and CI reads --json.
+    body = "import httpx\nx = 1  # mcp-migrate: ignore[R001] -- stale\n"
+    main(["check", str(project(tmp_path, "server.py", body)), "--json"])
+    payload = json.loads(capsys.readouterr().out)
+
+    assert len(payload["unused_suppressions"]) == 1
+    entry = payload["unused_suppressions"][0]
+    assert entry["rule"] == "R001"
+    assert entry["line"] == 2
+    assert entry["reason"] == "stale"
+    assert entry["path"].endswith("server.py")
+
+
+def test_unused_suppressions_is_always_present_even_when_empty(tmp_path, capsys):
+    # Required, like `suppressed`. An empty array is the common case, which
+    # is exactly the one worth making visible -- a key that appears only
+    # when non-empty forces every consumer to write the same `.get()`.
+    main(["check", str(project(tmp_path, "server.py", "import httpx\n")), "--json"])
+    assert json.loads(capsys.readouterr().out)["unused_suppressions"] == []
+
+
+def test_a_suppression_that_matched_is_not_reported_as_unused(tmp_path, capsys):
+    body = "import httpx\n" + f"{PY_TRIGGER}  # mcp-migrate: ignore[R001] -- deliberate\n"
+    main(["check", str(project(tmp_path, "server.py", body)), "--json"])
+    payload = json.loads(capsys.readouterr().out)
+
+    assert payload["suppressed"], "it did match"
+    assert payload["unused_suppressions"] == []
+
+
+def test_a_stale_directive_naming_two_rules_reports_both(tmp_path, capsys):
+    # One entry per rule id, so the shape matches `suppressed`. Nothing is
+    # lost by expanding: if the directive matched nothing, every rule in it
+    # is stale.
+    body = "import httpx\nx = 1  # mcp-migrate: ignore[R001, R006] -- stale\n"
+    main(["check", str(project(tmp_path, "server.py", body)), "--json"])
+    payload = json.loads(capsys.readouterr().out)
+
+    assert sorted(e["rule"] for e in payload["unused_suppressions"]) == ["R001", "R006"]
+    assert {e["line"] for e in payload["unused_suppressions"]} == {2}
+
+
 def test_a_suppressed_breaking_finding_changes_the_exit_code(tmp_path, capsys):
     # The consequence of the grade decision, stated as a test: this is
     # what makes the feature usable in CI, and also what makes the

--- a/tests/test_suppress.py
+++ b/tests/test_suppress.py
@@ -1,0 +1,225 @@
+"""Inline suppression.
+
+The property that matters most here is not that suppression works -- it
+is that it cannot be used quietly. A suppressed finding stops costing the
+grade, which makes this the one feature in the tool that can improve a
+score without improving the code. Every test below that asserts on
+*visibility* is guarding that, not being thorough for its own sake.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from mcp_migrate.cli import main, run_check_detailed
+from mcp_migrate.suppress import apply, parse_file, unused
+
+PY_TRIGGER = "mcp_session_id = request.headers.get('X-Sid')"
+TS_TRIGGER = 'const mcpSessionId = req.headers["x-sid"];'
+
+
+def project(tmp_path, name, body):
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    (tmp_path / name).write_text(body, encoding="utf-8")
+    return tmp_path
+
+
+# --- parsing -------------------------------------------------------------
+
+def test_parses_a_well_formed_directive():
+    s, problems = parse_file(Path("a.py"), f"{PY_TRIGGER}  # mcp-migrate: ignore[R001] -- deliberate\n")
+    assert not problems
+    assert s[0].rule_ids == ("R001",)
+    assert s[0].reason == "deliberate"
+    assert s[0].line == 1
+
+
+def test_parses_the_typescript_comment_syntax():
+    s, problems = parse_file(Path("a.ts"), f"{TS_TRIGGER}  // mcp-migrate: ignore[R001] -- deliberate\n")
+    assert not problems
+    assert s[0].rule_ids == ("R001",)
+
+
+def test_parses_several_rule_ids():
+    s, _ = parse_file(Path("a.py"), "x = 1  # mcp-migrate: ignore[R001, R006] -- both\n")
+    assert s[0].rule_ids == ("R001", "R006")
+
+
+@pytest.mark.parametrize("sep", ["--", ":"])
+def test_either_reason_separator_works(sep):
+    s, _ = parse_file(Path("a.py"), f"x = 1  # mcp-migrate: ignore[R001] {sep} why\n")
+    assert s[0].reason == "why"
+
+
+def test_rule_ids_are_case_insensitive():
+    s, _ = parse_file(Path("a.py"), "x = 1  # mcp-migrate: ignore[r001] -- why\n")
+    assert s[0].rule_ids == ("R001",)
+
+
+# --- what is deliberately refused ---------------------------------------
+
+def test_a_blanket_ignore_is_refused_and_reported():
+    # Not silently dropped: someone wrote this believing it worked, and
+    # the finding it was meant to silence is about to appear anyway.
+    s, problems = parse_file(Path("a.py"), "x = 1  # mcp-migrate: ignore\n")
+    assert s == []
+    assert problems
+    assert "rule id" in problems[0].message
+
+
+def test_a_bad_rule_id_is_reported():
+    _s, problems = parse_file(Path("a.py"), "x = 1  # mcp-migrate: ignore[nonsense] -- why\n")
+    assert problems
+    assert "not a rule id" in problems[0].message
+
+
+def test_a_missing_reason_is_reported_but_still_suppresses():
+    # Reported, because an unexplained suppression is unreviewable later.
+    # Still honoured, because failing closed here would mean a malformed
+    # comment silently reintroduces a finding someone thought was handled.
+    s, problems = parse_file(Path("a.py"), "x = 1  # mcp-migrate: ignore[R001]\n")
+    assert s and s[0].rule_ids == ("R001",)
+    assert problems and "no reason" in problems[0].message
+
+
+def test_an_unrelated_comment_is_not_a_directive():
+    s, problems = parse_file(Path("a.py"), "x = 1  # we should ignore R001 here one day\n")
+    assert not s and not problems
+
+
+# --- application ---------------------------------------------------------
+
+def test_a_suppressed_finding_is_removed_and_the_rest_survive(tmp_path):
+    body = (
+        "import httpx\n"
+        f"{PY_TRIGGER}  # mcp-migrate: ignore[R001] -- deliberate\n"
+        f"other_{PY_TRIGGER}\n"
+    )
+    result = run_check_detailed(project(tmp_path, "server.py", body))
+
+    assert len(result.suppressed) == 1
+    assert result.suppressed[0].line == 2
+    assert all(f.line != 2 for f in result.findings)
+    assert any(f.rule_id == "R001" for f in result.findings), "line 3 still fires"
+
+
+def test_suppression_is_rule_scoped(tmp_path):
+    # ignore[R006] must not silence an R001 finding on the same line.
+    body = "import httpx\n" + f"{PY_TRIGGER}  # mcp-migrate: ignore[R006] -- wrong rule\n"
+    result = run_check_detailed(project(tmp_path, "server.py", body))
+    assert result.suppressed == []
+    assert any(f.rule_id == "R001" for f in result.findings)
+
+
+def test_suppression_is_line_scoped(tmp_path):
+    body = (
+        "import httpx\n"
+        "# mcp-migrate: ignore[R001] -- on its own line, applies to nothing\n"
+        f"{PY_TRIGGER}\n"
+    )
+    result = run_check_detailed(project(tmp_path, "server.py", body))
+    assert result.suppressed == []
+
+
+def test_a_project_level_finding_cannot_be_suppressed():
+    # No line to attach a comment to. Allowing one from an arbitrary line
+    # elsewhere would be a blanket ignore in disguise.
+    class F:
+        rule_id, path, line = "R010", None, None
+
+    kept, suppressed = apply([F()], [])
+    assert kept and not suppressed
+
+
+def test_unused_suppressions_are_detected():
+    s, _ = parse_file(Path("a.py"), "x = 1  # mcp-migrate: ignore[R001] -- stale\n")
+    assert unused(s) == s
+    apply([], s)
+    assert unused(s) == s, "nothing matched, so it stays unused"
+
+
+# --- the grade, and keeping it honest ------------------------------------
+
+def test_a_suppressed_finding_does_not_cost_the_grade(tmp_path):
+    trigger = f"{PY_TRIGGER}\n"
+    dirty = run_check_detailed(project(tmp_path / "a", "server.py", "import httpx\n" + trigger))
+    clean = run_check_detailed(project(
+        tmp_path / "b", "server.py",
+        "import httpx\n" + f"{PY_TRIGGER}  # mcp-migrate: ignore[R001] -- deliberate\n",
+    ))
+    assert clean.value > dirty.value, (
+        "a suppression that still costs the grade is not a suppression -- "
+        "the user's only remaining move would be to stop running the tool"
+    )
+
+
+def test_the_suppression_count_is_printed_without_a_flag(tmp_path, capsys):
+    # Not behind --show-suppressions. The count is part of reading the
+    # grade honestly, and hiding it would make this a quiet way to improve
+    # a score.
+    body = "import httpx\n" + f"{PY_TRIGGER}  # mcp-migrate: ignore[R001] -- deliberate\n"
+    main(["check", str(project(tmp_path, "server.py", body))])
+    out = capsys.readouterr().out
+    assert "suppressed" in out
+
+
+def test_show_suppressions_lists_each_one_with_its_reason(tmp_path, capsys):
+    body = "import httpx\n" + f"{PY_TRIGGER}  # mcp-migrate: ignore[R001] -- proxy shim\n"
+    main(["check", str(project(tmp_path, "server.py", body)), "--show-suppressions"])
+    out = capsys.readouterr().out
+    assert "proxy shim" in out
+    assert "R001" in out
+
+
+def test_malformed_directives_are_surfaced_on_the_console(tmp_path, capsys):
+    body = "import httpx\nx = 1  # mcp-migrate: ignore\n"
+    main(["check", str(project(tmp_path, "server.py", body))])
+    assert "suppression ignored" in capsys.readouterr().out
+
+
+def test_unused_suppressions_are_surfaced_on_the_console(tmp_path, capsys):
+    body = "import httpx\nx = 1  # mcp-migrate: ignore[R001] -- stale\n"
+    main(["check", str(project(tmp_path, "server.py", body))])
+    assert "unused suppression" in capsys.readouterr().out
+
+
+# --- machine-readable ----------------------------------------------------
+
+def test_json_carries_the_suppressions_and_their_reasons(tmp_path, capsys):
+    body = "import httpx\n" + f"{PY_TRIGGER}  # mcp-migrate: ignore[R001] -- proxy shim\n"
+    main(["check", str(project(tmp_path, "server.py", body)), "--json"])
+    payload = json.loads(capsys.readouterr().out)
+
+    assert len(payload["suppressed"]) == 1
+    assert payload["suppressed"][0]["rule"] == "R001"
+    assert payload["suppressed"][0]["reason"] == "proxy shim"
+    assert payload["suppressed"][0]["line"] == 2
+
+
+def test_suppressed_is_always_present_even_when_empty(tmp_path, capsys):
+    main(["check", str(project(tmp_path, "server.py", "import httpx\n")), "--json"])
+    assert json.loads(capsys.readouterr().out)["suppressed"] == []
+
+
+def test_suppressed_findings_are_not_in_findings_or_counts(tmp_path, capsys):
+    body = "import httpx\n" + f"{PY_TRIGGER}  # mcp-migrate: ignore[R001] -- deliberate\n"
+    main(["check", str(project(tmp_path, "server.py", body)), "--json"])
+    payload = json.loads(capsys.readouterr().out)
+
+    assert all(f["line"] != 2 for f in payload["findings"])
+    assert sum(payload["counts"].values()) == len(payload["findings"])
+
+
+def test_a_suppressed_breaking_finding_changes_the_exit_code(tmp_path, capsys):
+    # The consequence of the grade decision, stated as a test: this is
+    # what makes the feature usable in CI, and also what makes the
+    # visibility guarantees above load-bearing.
+    body = "import httpx\n" + PY_TRIGGER + "\n"
+    assert main(["check", str(project(tmp_path / "a", "server.py", body))]) == 1
+    capsys.readouterr()
+
+    suppressed = "import httpx\n" + f"{PY_TRIGGER}  # mcp-migrate: ignore[R001] -- deliberate\n"
+    assert main(["check", str(project(tmp_path / "b", "server.py", suppressed))]) == 0
+    capsys.readouterr()


### PR DESCRIPTION
Fixes #180.

```python
mcp_session_id = req.headers["X-Sid"]  # mcp-migrate: ignore[R001] -- proxy shim, not MCP session state
```
```ts
const mcpSessionId = req.headers["x-sid"];  // mcp-migrate: ignore[R001] -- proxy shim
```

## The design question you flagged as the real work

> **Does a suppressed finding still count against the grade?**

**It doesn't.** A suppression that still costs the grade isn't a suppression — the user's only remaining move would be to stop running the tool, which is precisely the outcome this feature exists to prevent.

You also named the cost: the grade becomes partly self-reported. That's real, and burying it would be the wrong trade, so three things make it auditable:

| | |
|---|---|
| **The count always prints** | never behind a flag — it's part of reading the grade honestly |
| **`--show-suppressions`** | lists every one with file, rule and reason |
| **Unused suppressions are reported** | matched nothing → either fixed or the code moved, and stale ones can't silently accumulate |

That's the same standard #101 applied to the stale badge: the claim may be wrong, but it can't be *quietly* wrong. If you'd rather suppressed findings still counted, it's one line in `suppress.apply` — but then I think the feature doesn't do its job.

## Four things deliberately refused

Each because the sloppy version rots:

- **Blanket `ignore` with no rule id** — it would also silence rules written next year. Refused **and reported**, not silently dropped: someone wrote it believing it worked, and the finding is about to appear anyway.
- **A bad rule id** — reported.
- **A missing reason** — reported, but still honoured. Failing closed there would mean a malformed comment silently reintroduces a finding somebody thought was handled.
- **Project-level findings can't be suppressed at all.** R010 asks a question about the whole tree and has no line to attach a comment to. Letting an arbitrary line elsewhere silence it would be a blanket ignore wearing a disguise.

Suppression is both rule-scoped and line-scoped — `ignore[R006]` won't silence an R001 on the same line, and a directive on its own line applies to nothing. Both are tested.

## Compatibility

`run_check` keeps its 5-tuple signature. Widening it breaks callers silently, and several tests unpack exactly five values — the full result moved to `run_check_detailed` / `CheckResult`, and `run_check` delegates.

`--json` gains a **required** `suppressed` array, each entry carrying its `reason`. `schemas/check-json.schema.json` is updated to match so the executable contract stays executable. That's a `Changed` entry for the CHANGELOG — say the word and I'll add it here rather than leaving it to you.

## Tests (24)

More than half assert on **visibility** rather than on suppression working, because that's the half that can be quietly wrong: the count printing without a flag, `--show-suppressions` showing reasons, malformed directives surfacing, unused suppressions surfacing, JSON carrying reasons, suppressed findings absent from `counts`, and the grade/exit-code consequences stated explicitly.

Full suite: **483 passed**.

---

The baseline file (#181) is the other half of this — inline suppression is "this line is fine forever", a baseline is "not today". Happy to take that next if this shape is agreeable.