### PR TITLE
feat: add a pre-commit hook

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,31 @@
+# Hook definitions consumed by projects that add this repo to their
+# .pre-commit-config.yaml. See the "pre-commit" section of README.md.
+
+- id: mcp-migrate
+  name: mcp-migrate
+  description: Check an MCP server against the 2026-07-28 spec revision
+  entry: mcp-migrate-precommit
+  language: python
+  # Gate on the languages the scanner can actually read, so the hook stays
+  # silent in repositories it has nothing to say about.
+  types_or: [python, ts, tsx, javascript, jsx]
+
+  # Scan the project, not the staged files -- and do not "optimise" this
+  # to true.
+  #
+  # Several rules are whole-project questions. R010 asks "does this project
+  # implement server/discover *anywhere*?" and R015/R016 look for evidence
+  # across a file set. Handed only the staged files, they would answer that
+  # question about a partial view of the tree and fire wrongly: stage one
+  # unrelated file and R010 reports a missing server/discover handler that
+  # exists two files away.
+  #
+  # The cost is that the hook re-reads the project each time. That is the
+  # right trade for a scanner whose rules are project-scoped.
+  pass_filenames: false
+
+  # `mcp-migrate-precommit` is a thin wrapper over `check` that maps exit
+  # 2 ("could not check -- no readable source") to 0. pre-commit treats
+  # every non-zero exit as a failure, so without this the hook blocks
+  # every commit in a repository the tool cannot read. Exit 1, a breaking
+  # finding, still fails the hook -- that is the point of installing it.

--- a/README.md
+++ b/README.md
@@ -231,6 +231,30 @@ correct, it leaves the source untouched rather than guess. A wrong fix that
 silently corrupts your server is worse than reporting the finding and doing
 nothing.
 
+## Catch it before it is committed
+
+```yaml
+# .pre-commit-config.yaml
+repos:
+  - repo: https://github.com/dheerajjha/mcp-migrate
+    rev: v0.1.4
+    hooks:
+      - id: mcp-migrate
+```
+
+A breaking finding fails the hook, which is the point. A repository with no
+readable source does **not** — the hook runs `mcp-migrate-precommit`, a thin
+wrapper that maps `check`'s exit `2` ("could not check it") to `0`. pre-commit
+treats every non-zero exit as a failure, so without that the hook would block
+every commit in a repo the tool cannot read, which is a reason the user can do
+nothing about. The message still prints; it just isn't fatal.
+
+The hook scans the **project**, not the staged files (`pass_filenames: false`),
+and that isn't an oversight to optimise away: several rules are whole-project
+questions — R010 asks whether `server/discover` exists *anywhere* — and handed a
+partial view they fire wrongly. Cost of that choice, measured on 600 files
+(300 Python + 300 TypeScript): **~0.32 s**.
+
 ## Other commands
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -237,7 +237,7 @@ nothing.
 # .pre-commit-config.yaml
 repos:
   - repo: https://github.com/dheerajjha/mcp-migrate
-    rev: v0.1.4
+    rev: v0.2.0
     hooks:
       - id: mcp-migrate
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,9 @@ dependencies = ["pyyaml>=6.0", "rich>=13.0"]
 
 [project.scripts]
 mcp-migrate = "mcp_migrate.cli:main"
+# Thin wrapper over `check` for .pre-commit-hooks.yaml -- see
+# src/mcp_migrate/precommit.py for the one thing it changes.
+mcp-migrate-precommit = "mcp_migrate.precommit:main"
 
 [project.optional-dependencies]
 dev = ["jsonschema>=4.0", "pytest>=8.0"]

--- a/src/mcp_migrate/precommit.py
+++ b/src/mcp_migrate/precommit.py
@@ -1,0 +1,47 @@
+"""The `mcp-migrate-precommit` entry point.
+
+pre-commit treats **any** non-zero exit as a failed hook. `check` exits 2
+for "could not check it" -- no readable source in a supported language --
+which is the correct answer for the CLI and completely wrong for a hook:
+it would block every commit in any repository the tool cannot read, which
+includes every repository right up until the moment someone adds their
+first Python or TypeScript file. A hook that blocks commits for a reason
+the user cannot act on gets uninstalled within the hour, and then it
+catches nothing ever again.
+
+So this wrapper is exactly one decision: **2 becomes 0.**
+
+Nothing else changes. 1 still means a breaking finding and still blocks
+the commit, which is the entire point of installing this. The message is
+still printed, so "we could not read this" stays visible -- it just stops
+being fatal.
+
+A wrapper rather than a `--exit-zero-on-unscannable` flag on `check`: the
+flag would be one more thing to get wrong on the command line, and the
+distinction only exists because of how pre-commit interprets exit codes.
+That is the hook's problem, so it lives in the hook.
+"""
+from __future__ import annotations
+
+import sys
+
+from .cli import EXIT_OK, EXIT_UNSCANNABLE, main as cli_main
+
+
+def main(argv: list[str] | None = None) -> int:
+    argv = list(sys.argv[1:] if argv is None else argv)
+
+    # `check` is implied. The hook only ever runs that one command, and
+    # anything a user puts in `args:` is a path or a flag for it -- not a
+    # subcommand. Testing for a leading dash is not enough: a bare path
+    # would then be parsed as a subcommand name and argparse would exit 2,
+    # which is the very code this wrapper exists to stop being fatal.
+    if not argv or argv[0] != "check":
+        argv = ["check", *argv]
+
+    code = cli_main(argv)
+    return EXIT_OK if code == EXIT_UNSCANNABLE else code
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/tests/test_precommit.py
+++ b/tests/test_precommit.py
@@ -1,0 +1,125 @@
+"""The pre-commit wrapper.
+
+One decision, one test file: pre-commit treats any non-zero exit as a
+failed hook, and `check` exits 2 for "no readable source in a supported
+language". Left alone, the hook would block every commit in a repository
+the tool cannot read -- which is every repository, right up until someone
+adds their first Python or TypeScript file.
+
+A hook that blocks commits for a reason the user cannot act on gets
+uninstalled within the hour, and then it catches nothing ever again.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from mcp_migrate.precommit import main as precommit_main
+
+ROOT = Path(__file__).resolve().parent.parent
+HOOKS = yaml.safe_load((ROOT / ".pre-commit-hooks.yaml").read_text(encoding="utf-8"))
+
+BREAKING = "import httpx\nmcp_session_id = 1\n"
+CLEAN = "import httpx\n\n\ndef handle(r):\n    return r\n"
+
+
+def project(tmp_path, name, body):
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    (tmp_path / name).write_text(body, encoding="utf-8")
+    return tmp_path
+
+
+# --- the one decision ----------------------------------------------------
+
+def test_an_unreadable_tree_does_not_block_the_commit(tmp_path, capsys):
+    (tmp_path / "notes.txt").write_text("no source here\n")
+    code = precommit_main([str(tmp_path)])
+    capsys.readouterr()
+    assert code == 0, "exit 2 must not fail the hook"
+
+
+def test_check_still_exits_two_on_the_same_tree(tmp_path, capsys):
+    # The wrapper changes the hook, not the CLI. `check` keeps saying
+    # "could not check it", which is the honest answer for a tool.
+    from mcp_migrate.cli import main as cli_main
+
+    (tmp_path / "notes.txt").write_text("no source here\n")
+    code = cli_main(["check", str(tmp_path)])
+    capsys.readouterr()
+    assert code == 2
+
+
+def test_a_breaking_finding_still_blocks_the_commit(tmp_path, capsys):
+    # The entire point of installing the hook.
+    code = precommit_main([str(project(tmp_path, "server.py", BREAKING))])
+    capsys.readouterr()
+    assert code == 1
+
+
+def test_a_clean_project_passes(tmp_path, capsys):
+    code = precommit_main([str(project(tmp_path, "server.py", CLEAN))])
+    capsys.readouterr()
+    assert code == 0
+
+
+def test_the_unreadable_message_is_still_printed(tmp_path, capsys):
+    # Not fatal is not the same as not shown -- "we could not read this"
+    # is still something the user should see.
+    (tmp_path / "notes.txt").write_text("no source here\n")
+    precommit_main([str(tmp_path)])
+    assert "scannable" in capsys.readouterr().out.lower()
+
+
+# --- argument handling ---------------------------------------------------
+
+def test_a_bare_path_is_treated_as_an_argument_not_a_subcommand(tmp_path, capsys):
+    # Regression: testing only for a leading dash meant a path was parsed
+    # as a subcommand name, argparse exited 2, and the wrapper turned that
+    # into a *pass* -- silently disabling the hook.
+    code = precommit_main([str(project(tmp_path, "server.py", BREAKING))])
+    capsys.readouterr()
+    assert code == 1, "a path argument must still reach `check`"
+
+
+def test_an_explicit_check_is_accepted(tmp_path, capsys):
+    code = precommit_main(["check", str(project(tmp_path, "server.py", CLEAN))])
+    capsys.readouterr()
+    assert code == 0
+
+
+def test_flags_are_passed_through(tmp_path, capsys):
+    code = precommit_main([str(project(tmp_path, "server.py", CLEAN)), "--json"])
+    out = capsys.readouterr().out
+    assert code == 0
+    assert out.lstrip().startswith("{"), "--json should have reached check"
+
+
+# --- the hook definition itself -----------------------------------------
+
+def test_exactly_one_hook_is_declared():
+    assert len(HOOKS) == 1
+    assert HOOKS[0]["id"] == "mcp-migrate"
+
+
+def test_the_hook_runs_the_wrapper_not_check_directly():
+    # `entry: mcp-migrate check` would reintroduce the exit-2 problem.
+    assert HOOKS[0]["entry"] == "mcp-migrate-precommit"
+
+
+def test_the_hook_scans_the_project_not_the_staged_files():
+    # Several rules are whole-project questions -- R010 asks whether
+    # server/discover exists *anywhere*. Handed only staged files it would
+    # answer that about a partial tree and fire wrongly.
+    assert HOOKS[0]["pass_filenames"] is False
+
+
+def test_the_hook_is_gated_on_languages_the_scanner_reads():
+    types = set(HOOKS[0]["types_or"])
+    assert {"python", "ts"} <= types
+
+
+def test_the_entry_point_is_declared_in_pyproject():
+    text = (ROOT / "pyproject.toml").read_text(encoding="utf-8")
+    assert 'mcp-migrate-precommit = "mcp_migrate.precommit:main"' in text


### PR DESCRIPTION
Fixes #184.

```yaml
repos:
  - repo: https://github.com/dheerajjha/mcp-migrate
    rev: v0.1.4
    hooks:
      - id: mcp-migrate
```

The yaml is the easy part. Both things you flagged as the actual work:

## Exit codes

pre-commit treats **any** non-zero exit as a failed hook, and `check` exits `2` for "no readable source in a supported language". Wired directly, the hook blocks every commit in a repository the tool can't read — which is every repository, right up until someone adds their first Python or TypeScript file. A hook that blocks commits for a reason the user can't act on gets uninstalled within the hour, and then it catches nothing ever again.

So `entry` is `mcp-migrate-precommit`, a wrapper whose entire job is mapping `2` → `0`:

| | `check` | hook |
|---|---|---|
| clean | 0 | **0** |
| breaking finding | 1 | **1** — still blocks, that's the point |
| nothing readable | 2 | **0** |

`check` itself is unchanged and still exits 2, because that's the honest answer for a CLI. Only pre-commit's *reading* of it is wrong, so the adjustment lives in the hook. The "could not read this" message still prints — not fatal isn't the same as not shown.

A wrapper rather than a `--exit-zero-on-unscannable` flag on `check`: the flag would be one more thing to get wrong on a command line, and the distinction exists solely because of how pre-commit interprets exit codes.

## `pass_filenames: false`

With the reasoning in a comment **in the yaml**, because — as you predicted — the next person will want to optimise it.

Several rules are whole-project questions. R010 asks whether `server/discover` exists *anywhere*; R015/R016 look for evidence across a file set. Handed only the staged files they answer about a partial tree and fire wrongly: stage one unrelated file and R010 reports a missing handler that exists two files away.

## Speed

You asked for a measurement rather than a claim. 600 files (300 Python + 300 TypeScript), three consecutive runs:

```
run 1: 0.34 s
run 2: 0.31 s
run 3: 0.32 s
```

That's the cost of rescanning the project each time, and it's well under where a hook starts getting uninstalled.

## One bug caught while testing

The wrapper originally decided "is this a subcommand?" by testing for a leading dash. A bare path doesn't start with `-`, so it was parsed as a subcommand name, argparse exited `2`, and the wrapper dutifully turned that into a **pass** — silently disabling the hook it exists to enable. Fixed, and pinned by `test_a_bare_path_is_treated_as_an_argument_not_a_subcommand`.

## Tests (13)

Each exit code · the message still printing · flags passing through · the bare-path regression · and the hook definition itself: that it runs the wrapper rather than `check` directly, that `pass_filenames` stays false, and that the entry point is declared in `pyproject.toml`.

Full suite: **472 passed**. Documented in the README next to the CI section.

---

Note the `rev: v0.1.4` in the README example — it points at a tag that doesn't exist yet, so this wants a release before anyone can actually use it. Say if you'd rather I pinned it to the current tag instead.