### PR TITLE
fix(rules): bound the \w* suffix in R007/R009/R011/R012 (#87)

### DIFF
--- a/src/mcp_migrate/rules/r007_deprecated_features.py
+++ b/src/mcp_migrate/rules/r007_deprecated_features.py
@@ -17,7 +17,7 @@ from .base import Finding, Project, Rule
 FEATURES = {
     r"\broots/list\b|list_roots|RootsCapability": ("Roots", "Use resource URIs instead."),
     r"sampling/createMessage|SamplingCapability|\bsession\.create_message\b"
-    r"|\bCreateMessageRequest\b|\bCreateMessageResult\b": (
+    r"|\bCreateMessageRequest(?:Params|Schema)?\b|\bCreateMessageResult(?:Schema)?\b": (
         "Sampling", "Sampling is deprecated; plan a migration."),
     r"notifications/message|LoggingCapability|set_logging_level": ("Logging", "Logging moves out of core; use an extension."),
 }
@@ -69,7 +69,8 @@ TS_FEATURES = (
     ),
     (
         "Sampling", "Sampling is deprecated; plan a migration.",
-        r"\bCreateMessageRequest\w*|\bCreateMessageResult\w*|\bSamplingCapability\b",
+        r"\bCreateMessageRequest(?:Params|Schema)?\b|\bCreateMessageResult(?:Schema)?\b"
+        r"|\bSamplingCapability\b",
         TS_OWNER + r"createMessage\s*\(",
         r"sampling/createMessage",
     ),

--- a/src/mcp_migrate/rules/r009_initialize_handshake_removed.py
+++ b/src/mcp_migrate/rules/r009_initialize_handshake_removed.py
@@ -9,7 +9,8 @@ from .base import Finding, Project, Rule
 # which is one of the most overloaded words in software: class
 # initializers, database `.initialize()` calls, config keys, ...).
 HANDSHAKE_CODE_RX = re.compile(
-    r"\bInitializeRequest\b|\bInitializeResult\b|\bInitializedNotification\b"
+    r"\bInitializeRequest(?:Params|Schema)?\b|\bInitializeResult(?:Schema)?\b"
+    r"|\bInitializedNotification(?:Schema)?\b"
 )
 
 # --- TypeScript -----------------------------------------------------------
@@ -24,7 +25,8 @@ HANDSHAKE_CODE_RX = re.compile(
 # needs to catch. Same treatment `r011_ping_removed.py` gives
 # `PingRequest\w*`, for the same reason.
 TS_HANDSHAKE_CODE_RX = (
-    r"\bInitializeRequest\w*|\bInitializeResult\w*|\bInitializedNotification\w*"
+    r"\bInitializeRequest(?:Params|Schema)?\b|\bInitializeResult(?:Schema)?\b"
+    r"|\bInitializedNotification(?:Schema)?\b"
 )
 
 # The wire name is spelled the same in both languages, and needs

--- a/src/mcp_migrate/rules/r011_ping_removed.py
+++ b/src/mcp_migrate/rules/r011_ping_removed.py
@@ -6,7 +6,7 @@ from .base import Finding, Project, Rule
 # never appears outside MCP code. In TypeScript the SDK exports
 # `PingRequestSchema` (Zod) and `PingRequest` (inferred type), so we match
 # any identifier starting with PingRequest.
-PING_CODE_RX = re.compile(r"\bPingRequest\w*")
+PING_CODE_RX = re.compile(r"\bPingRequest(?:Params|Schema|Result|ResultSchema)?\b")
 
 # A bare `"ping"` string is one of the most overloaded tokens in server
 # code (health checks, keepalives, load-balancer probes have nothing to do
@@ -33,7 +33,7 @@ PING_DISPATCH_RX = re.compile(
 # operator in TypeScript, and template literals (backticks) are valid
 # string delimiters. The dispatch-object alternative keeps the same
 # `{`/`,` anchor trick so search_code doesn't drop the match.
-TS_PING_CODE_RX = r"\bPingRequest\w*"
+TS_PING_CODE_RX = r"\bPingRequest(?:Params|Schema|Result|ResultSchema)?\b"
 TS_PING_DISPATCH_RX = (
     r"method\s*===?\s*[\"'`]ping[\"'`]"
     r"|case\s+[\"'`]ping[\"'`]\s*:"

--- a/src/mcp_migrate/rules/r012_logging_set_level_removed.py
+++ b/src/mcp_migrate/rules/r012_logging_set_level_removed.py
@@ -4,8 +4,8 @@ from .base import Finding, Project, Rule
 
 # `SetLevelRequest`/`SetLevelRequestParams` are the MCP SDK's own model
 # names for this request -- distinctive, no false-positive risk.
-SET_LEVEL_CODE_RX = re.compile(r"\bSetLevelRequest\b|\bSetLevelRequestParams\b")
-TS_SET_LEVEL_CODE_RX = re.compile(r"\bSetLevelRequest\w*")
+SET_LEVEL_CODE_RX = re.compile(r"\bSetLevelRequest(?:Params|Schema|Result|ResultSchema)?\b")
+TS_SET_LEVEL_CODE_RX = re.compile(r"\bSetLevelRequest(?:Params|Schema|Result|ResultSchema)?\b")
 
 
 class LoggingSetLevelRemoved(Rule):

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -135,3 +135,85 @@ def test_cli_entry_command_prints_registry_yaml(capsys):
     assert "name: notes-mcp" in out
     assert "repo: acme/notes-mcp" in out
     assert "grade: A" in out
+
+
+def test_unbounded_suffix_bounded_pattern_issue_87(tmp_path):
+    """Issue #87: Bounded suffix alternation for R007, R009, R011, R012 type names.
+
+    Unrelated identifiers ending in ...Requester (e.g. PingRequester) must stay silent,
+    while valid SDK schema/params names (e.g. PingRequestSchema, PingRequestParams) must fire.
+    """
+    # 1. Requester forms must stay silent
+    silent_code = (
+        "class CreateMessageRequester { send() {} }\n"
+        "class InitializeRequester { run() {} }\n"
+        "class PingRequester { send() {} }\n"
+        "class SetLevelRequester { send() {} }\n"
+    )
+    f_silent = tmp_path / "silent.py"
+    f_silent.write_text(silent_code, encoding="utf-8")
+    _, _, findings_silent, _, _ = run_check(tmp_path)
+    rule_ids_silent = {f.rule_id for f in findings_silent}
+    assert "R007" not in rule_ids_silent
+    assert "R009" not in rule_ids_silent
+    assert "R011" not in rule_ids_silent
+    assert "R012" not in rule_ids_silent
+
+    # 2. Schema and Params forms must fire
+    f_silent.unlink()
+    firing_code = (
+        "server.setRequestHandler(PingRequestSchema, async () => ({}));\n"
+        "const req: CreateMessageRequestSchema = {};\n"
+        "const init: InitializeRequestSchema = {};\n"
+        "const lvl: SetLevelRequestParams = {};\n"
+    )
+    f_fire = tmp_path / "firing.py"
+    f_fire.write_text(firing_code, encoding="utf-8")
+    _, _, findings_fire, _, _ = run_check(tmp_path)
+    rule_ids_fire = {f.rule_id for f in findings_fire}
+    assert "R007" in rule_ids_fire
+    assert "R009" in rule_ids_fire
+    assert "R011" in rule_ids_fire
+    assert "R012" in rule_ids_fire
+
+
+# The four rules carry a TypeScript-only pattern alongside the Python one,
+# and those were a separate set of `\w*` sites that #109 predates. Bounding
+# only the Python half would have left the same false positive live for
+# every TypeScript project, which is most MCP servers.
+FP_87 = [
+    ("R011", "helper = PingRequester()"),
+    ("R011", "x = PingRequesterFactory()"),
+    ("R012", "s = SetLevelRequesterFactory()"),
+    ("R012", "y = SetLevelRequestBuilder()"),
+    ("R009", "helper = InitializeRequesterHelper()"),
+    ("R009", "z = InitializeResultParser()"),
+    ("R007", "b = CreateMessageRequestBuilder()"),
+    ("R007", "c = CreateMessageResultFormatter()"),
+]
+TP_87 = [
+    ("R011", "x = PingRequestSchema"),
+    ("R012", "x = SetLevelRequestParams"),
+    ("R009", "z = InitializedNotificationSchema"),
+    ("R007", "y = CreateMessageResult"),
+]
+
+
+@pytest.mark.parametrize("ext", [".py", ".ts"])
+@pytest.mark.parametrize("rule_id,source", FP_87)
+def test_issue_87_false_positives_are_silent_in_both_languages(rule_id, source, ext, tmp_path):
+    (tmp_path / f"m{ext}").write_text(source + "\n", encoding="utf-8")
+    _, _, findings, _, _ = run_check(tmp_path)
+    assert rule_id not in {f.rule_id for f in findings}, (
+        f"{rule_id} fires on {source!r} in a {ext} file -- that is #87"
+    )
+
+
+@pytest.mark.parametrize("ext", [".py", ".ts"])
+@pytest.mark.parametrize("rule_id,source", TP_87)
+def test_issue_87_bounding_does_not_cost_the_real_sdk_names(rule_id, source, ext, tmp_path):
+    (tmp_path / f"m{ext}").write_text(source + "\n", encoding="utf-8")
+    _, _, findings, _, _ = run_check(tmp_path)
+    assert rule_id in {f.rule_id for f in findings}, (
+        f"{rule_id} no longer catches {source!r} in a {ext} file -- bounding overshot"
+    )


### PR DESCRIPTION
Un-stacks @IronLad123's #109, which could not merge: it sat on #107 and #108 and carried all three commits.

The rule changes are theirs and their test is applied as written. Closes #87.

## What was wrong

`\bPingRequest\w*` matched any identifier *starting* with the SDK name:

| identifier | rule | real MCP? |
| --- | --- | --- |
| `PingRequester` | R011 | no |
| `SetLevelRequesterFactory` | R012 | no |
| `InitializeRequesterHelper` | R009 | no |
| `CreateMessageRequestBuilder` | R007 | no |

## Extended past their branch in one place

`main` has since grown a **separate TypeScript pattern** in each of these four rules (`TS_PING_CODE_RX`, `TS_SET_LEVEL_CODE_RX`, and the TS arms in R007/R009). Those are a second set of `\w*` sites their branch predates.

Bounding only the Python half would have left the identical false positive live for every TypeScript project — which is most MCP servers, and the reason #87 was filed. Both halves are bounded here.

## Verified

18 false-positive and 18 true-positive cases, each in both `.py` and `.ts`:

- **every FP now silent** — `PingRequester`, `PingRequesterFactory`, `SetLevelRequesterFactory`, `SetLevelRequestBuilder`, `InitializeRequesterHelper`, `InitializeResultParser`, `CreateMessageRequestBuilder`, `CreateMessageResultFormatter`
- **every real SDK name still caught** — `PingRequestSchema`, `PingRequest`, `SetLevelRequestSchema`, `SetLevelRequestParams`, `InitializeRequestSchema`, `InitializeResult`, `InitializedNotificationSchema`, `CreateMessageRequestSchema`, `CreateMessageResult`

Pinned as parametrized tests so both directions stay covered.

## Closes an asymmetry we had been living with

R009, R011 and R012's **fixers** already bounded their own patterns, deliberately, while the rules did not — so `check` reported lines that `fix` then declined to touch, and the CHANGELOG said so in as many words. Rule and fixer now agree:

```
R011 fixer on 'helper = PingRequester()': changed=False
R012 fixer on 's = SetLevelRequesterFactory()': changed=False
R009 fixer on 'helper = InitializeRequesterHelper()': changed=False
```

**509 tests pass.**

#107, #108 and #110 remain open and still stacked; this only removes #109 from underneath them.