### PR TITLE
feat(r003): add fixer for missing Mcp-Method/Mcp-Name routing headers (#16)

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ Every change is tagged `safe` or `review` in the diff output:
 
 Pass `--safe-only` to apply only `safe` fixers, `--rule R006` to restrict to
 one rule, `--include-tests` to also fix test/fixture paths (skipped by
-default, same rule as `check`). Only 18 of the 21 rules ship a fixer at all --
+default, same rule as `check`). Only 19 of the 21 rules ship a fixer at all --
 see the table below and [`mcp-migrate fixers`](#other-commands). Fixers are
 deliberately conservative: when a fixer can't be sure a transformation is
 correct, it leaves the source untouched rather than guess. A wrong fix that
@@ -269,7 +269,7 @@ mcp-migrate entry --repo owner/name   # print a registry/servers/*.yaml entry fo
 | ---- | -------- | ------------ | ----- |
 | [R001](src/mcp_migrate/rules/r001_session_id.py) | breaking | `Mcp-Session-Id` is gone from the Streamable HTTP transport ([SEP-2567](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2567)). | yes (`review`) |
 | [R002](src/mcp_migrate/rules/r002_connection_state.py) | breaking | Servers are required to be stateless ([SEP-2567](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2567)); a module-level dict keyed by connection breaks behind a load balancer or a restart. | yes (`review`) |
-| [R003](src/mcp_migrate/rules/r003_routing_headers.py) | advisory | Hand-rolled HTTP clients that skip the new required `Mcp-Method`/`Mcp-Name` [routing headers](https://modelcontextprotocol.io/specification/2026-07-28/basic/transports/streamable-http) get rejected by anything enforcing the new transport. | no |
+| [R003](src/mcp_migrate/rules/r003_routing_headers.py) | advisory | Hand-rolled HTTP clients that skip the new required `Mcp-Method`/`Mcp-Name` [routing headers](https://modelcontextprotocol.io/specification/2026-07-28/basic/transports/streamable-http) get rejected by anything enforcing the new transport. | yes (`review`) |
 | [R004](src/mcp_migrate/rules/r004_tool_ordering.py) | advisory | [`tools/list` order](https://modelcontextprotocol.io/specification/draft/changelog) is not guaranteed; non-deterministic ordering defeats caching. | yes (`safe`) |
 | [R005](src/mcp_migrate/rules/r005_extensions.py) | advisory | Optional capabilities negotiate through an [`extensions`](https://modelcontextprotocol.io/specification/draft/changelog) map that isn't declared. | yes (`safe`) |
 | [R006](src/mcp_migrate/rules/r006_sse_transport.py) | deprecated | [HTTP+SSE](https://modelcontextprotocol.io/specification/draft/changelog) is deprecated in favor of Streamable HTTP; stays in the spec 12+ months, then leaves. | yes (`review`) |

--- a/cookbook/14-routing-headers.md
+++ b/cookbook/14-routing-headers.md
@@ -1,7 +1,7 @@
 # Required `Mcp-Method` / `Mcp-Name` routing headers
 
 - **Rule:** [R003](../src/mcp_migrate/rules/r003_routing_headers.py)
-- **Fixer:** none
+- **Fixer:** [`RoutingHeadersFixer`](../src/mcp_migrate/fixers/r003_routing_headers.py) (`review` confidence — adds headers to inline `headers={...}` dicts and leaves TODOs elsewhere)
 - **Severity:** advisory (downgraded from an earlier `breaking` after a real
   false-positive incident -- see the rule source's comment for the
   mcp-atlassian story before reaching for a fixer here)

--- a/cookbook/README.md
+++ b/cookbook/README.md
@@ -6,7 +6,7 @@ no tests, no fixture files -- just a worked before/after example and the
 gotchas you hit doing it for real.
 
 `mcp-migrate check` and `mcp-migrate fix` tell you *that* something broke and,
-for eighteen rules, fix the mechanical part automatically. The cookbook is where
+for nineteen rules, fix the mechanical part automatically. The cookbook is where
 the *rest* of the migration lives -- the part a regex can't do because it
 requires a judgment call (what do you name the new handle argument? where
 does the durable store live? what does your `server/discover` response say
@@ -44,7 +44,7 @@ All eighteen are written. There are no stubs left.
 | 11 | [Tasks moved to an extension, polling replaces blocking result](11-tasks-polling.md) | R019 | R019 (review) |
 | 12 | [Dynamic Client Registration deprecated](12-dynamic-client-registration-deprecated.md) | R020 | R020 (review) |
 | 13 | [JSON Schema 2020-12 required](13-json-schema-2020-12.md) | R021 | R021 (safe) |
-| 14 | [Required Mcp-Method / Mcp-Name routing headers](14-routing-headers.md) | R003 | none |
+| 14 | [Required Mcp-Method / Mcp-Name routing headers](14-routing-headers.md) | R003 | R003 (review) |
 | 15 | [Deterministic tools/list ordering](15-deterministic-tool-ordering.md) | R004 | R004 (safe, list-literal shape only) |
 | 16 | [extensions map on ServerCapabilities](16-extensions-map.md) | R005 | R005 (safe) |
 | 17 | [Trace context propagation from _meta](17-trace-context-propagation.md) | R008 | R008 (review) |

--- a/src/mcp_migrate/fixers/r003_routing_headers.py
+++ b/src/mcp_migrate/fixers/r003_routing_headers.py
@@ -1,0 +1,277 @@
+"""Fixer for R003 -- Mcp-Method / Mcp-Name routing headers on hand-rolled HTTP.
+
+Hand-rolled MCP wire traffic must carry routing headers so proxies can
+dispatch without parsing the body. There is no single mechanical value for
+every call site (method/name may be dynamic), so this fixer handles only
+the narrowest safe shape -- an inline ``headers={...}`` dict on a
+``.post()``/``.request()`` call -- and leaves a TODO everywhere else.
+Confidence "review": header values still need a human pass.
+"""
+from __future__ import annotations
+
+import ast
+import re
+from pathlib import Path
+
+from mcp_migrate.rules.r003_routing_headers import (
+    HAND_ROLLED_CALL,
+    HTTP_LIBS,
+    MCP_METHOD_RX,
+    NAME_REQUIRED_RX,
+    _imports_mcp,
+)
+
+from ._textedit import find_matching_close, leading_ws
+from .base import Fixer, FixResult
+
+COOKBOOK = "cookbook/14-routing-headers.md"
+SPEC_URL = (
+    "https://modelcontextprotocol.io/specification/2026-07-28/basic/transports/streamable-http"
+)
+TODO = (
+    "# TODO(mcp-migrate): add Mcp-Method"
+    " (and Mcp-Name for tools/call, resources/read, or prompts/get)"
+    f" — see {SPEC_URL} and {COOKBOOK}"
+)
+
+POST_CALL_RX = re.compile(r"\.(?:post|request)\s*\(")
+HEADERS_KW_RX = re.compile(r"\bheaders\s*=\s*\{")
+METHOD_LITERAL_RX = re.compile(r"""["']method["']\s*:\s*["']([^"']+)["']""")
+METHOD_IDENT_RX = re.compile(r"""["']method["']\s*:\s*([A-Za-z_][A-Za-z0-9_]*)""")
+NAME_IDENT_RX = re.compile(r"""["']name["']\s*:\s*([A-Za-z_][A-Za-z0-9_]*)""")
+
+
+def _file_context(source: str):
+    """Return gating flags mirroring the R003 rule's per-file checks."""
+    tree = None
+    try:
+        tree = ast.parse(source)
+    except SyntaxError:
+        pass
+
+    class _F:
+        def __init__(self, text: str, tree):
+            self.text = text
+            self.tree = tree
+            self.lines = text.splitlines()
+
+    f = _F(source, tree)
+    has_http = any(lib in source for lib in HTTP_LIBS)
+    mcp_surface = bool(MCP_METHOD_RX.search(source)) or _imports_mcp(f)
+    requires_name = bool(NAME_REQUIRED_RX.search(source))
+    missing_method = "Mcp-Method" not in source
+    missing_name = requires_name and "Mcp-Name" not in source
+    return has_http, mcp_surface, requires_name, missing_method, missing_name
+
+
+# These return None when the value cannot be recovered from the call site;
+# the caller then leaves the dict untouched and drops a TODO instead.
+#
+# They used to fall back to a placeholder -- `"<set-mcp-method>"`. That
+# produced source which compiles, runs, and sends a literal
+# `Mcp-Method: <set-mcp-method>` header on every request, and `check`
+# reported "Grade A. Nothing to fix." straight afterwards. An actionable
+# finding became a broken header the tool then called clean. A fixer that
+# cannot recover a value has to say so rather than invent one.
+def _method_value(call_span: str) -> str | None:
+    m = METHOD_LITERAL_RX.search(call_span)
+    if m:
+        return f'"{m.group(1)}"'
+    m = METHOD_IDENT_RX.search(call_span)
+    if m:
+        return m.group(1)
+    return None
+
+
+def _name_value(call_span: str) -> str | None:
+    m = NAME_IDENT_RX.search(call_span)
+    if m:
+        return m.group(1)
+    return None
+
+
+def _insert_headers_entries(
+    lines: list[str],
+    open_i: int,
+    open_col: int,
+    close_i: int,
+    close_col: int,
+    *,
+    add_method: bool,
+    add_name: bool,
+    method_val: str,
+    name_val: str,
+) -> None:
+    """Insert Mcp-Method / Mcp-Name entries before the closing ``}``."""
+    entries: list[str] = []
+    if add_method:
+        entries.append(f'"Mcp-Method": {method_val}')
+    if add_name:
+        entries.append(f'"Mcp-Name": {name_val}')
+    if not entries:
+        return
+
+    if open_i == close_i:
+        # Single-line headers={...} — splice comma-separated entries before ``}``.
+        line = lines[close_i]
+        inner = line[open_col + 1 : close_col].rstrip()
+        suffix = line[close_col + 1 :]
+        insertion = ", ".join(entries)
+        if inner.strip():
+            new_inner = f"{inner.rstrip()}, {insertion}"
+        else:
+            new_inner = insertion
+        lines[close_i] = line[: open_col + 1] + new_inner + "}" + suffix
+        return
+
+    content_indent = None
+    for k in range(open_i + 1, close_i + 1):
+        if lines[k].strip():
+            content_indent = leading_ws(lines[k])
+            break
+    if content_indent is None:
+        content_indent = leading_ws(lines[open_i]) + "    "
+
+    prev = close_i - 1
+    while prev > open_i and not lines[prev].strip():
+        prev -= 1
+    if prev >= open_i:
+        stripped = lines[prev].rstrip("\n")
+        if stripped.strip() and not stripped.rstrip().endswith(","):
+            nl = "\n" if lines[prev].endswith("\n") else ""
+            lines[prev] = stripped.rstrip() + "," + nl
+
+    insertion_lines = [f"{content_indent}{entry}," for entry in entries]
+    newline = "\n" if lines[close_i].endswith("\n") else ""
+    lines.insert(close_i, "".join(f"{line}{newline}" for line in insertion_lines))
+
+
+def _headers_dict_in_call(lines: list[str], call_i: int, close_i: int):
+    """Locate an inline headers={...} dict inside a .post/.request call."""
+    for line_idx in range(call_i, close_i + 1):
+        hm = HEADERS_KW_RX.search(lines[line_idx])
+        if not hm:
+            continue
+        brace_col = hm.end() - 1
+        h_closed = find_matching_close(lines, line_idx, brace_col)
+        if h_closed is None:
+            continue
+        h_close_i, h_close_col = h_closed
+        headers_span = (
+            "".join(lines[line_idx : h_close_i + 1])
+            if h_close_i > line_idx
+            else lines[line_idx][brace_col : h_close_col + 1]
+        )
+        return line_idx, brace_col, h_close_i, h_close_col, headers_span
+    return None
+
+
+class RoutingHeadersFixer(Fixer):
+    rule_id = "R003"
+    title = "Add Mcp-Method/Mcp-Name to inline headers={} on hand-rolled POSTs, TODO elsewhere"
+    confidence = "review"
+
+    def fix(self, source: str, path: Path) -> FixResult:
+        has_http, mcp_surface, requires_name, missing_method, missing_name = _file_context(source)
+        if not has_http or not mcp_surface:
+            return self.unchanged(source)
+        if not missing_method and not missing_name:
+            return self.unchanged(source)
+
+        lines = source.splitlines(keepends=True)
+        changes: list[str] = []
+        fixed_call_lines: set[int] = set()
+
+        # Pass 1: mechanical insert into inline headers={...} dicts.
+        call_targets: list[tuple[int, int, int, int, str, bool, bool]] = []
+        for i, line in enumerate(lines):
+            m = POST_CALL_RX.search(line)
+            if not m:
+                continue
+            open_col = m.end() - 1
+            closed = find_matching_close(lines, i, open_col)
+            if closed is None:
+                continue
+            close_i, close_col = closed
+            located = _headers_dict_in_call(lines, i, close_i)
+            if located is None:
+                continue
+            h_open_i, h_open_col, h_close_i, h_close_col, headers_span = located
+            if "Mcp-Method" in headers_span and (not requires_name or "Mcp-Name" in headers_span):
+                continue
+
+            add_method = missing_method and "Mcp-Method" not in headers_span
+            add_name = missing_name and requires_name and "Mcp-Name" not in headers_span
+            if not add_method and not add_name:
+                continue
+
+            call_span = "".join(lines[i : close_i + 1])
+
+            # Only claim this call site if every header we would write has a
+            # value recoverable from the call itself. Otherwise fall through
+            # to pass 2, which leaves the source untouched and annotates it.
+            if add_method and _method_value(call_span) is None:
+                continue
+            if add_name and _name_value(call_span) is None:
+                continue
+
+            call_targets.append(
+                (h_close_i, h_open_i, h_open_col, h_close_i, h_close_col, call_span, add_method, add_name)
+            )
+            fixed_call_lines.add(i)
+
+        for (
+            _sort_key,
+            h_open_i,
+            h_open_col,
+            h_close_i,
+            h_close_col,
+            call_span,
+            add_method,
+            add_name,
+        ) in sorted(call_targets, key=lambda t: t[0], reverse=True):
+            method_val = _method_value(call_span)
+            name_val = _name_value(call_span)
+            _insert_headers_entries(
+                lines,
+                h_open_i,
+                h_open_col,
+                h_close_i,
+                h_close_col,
+                add_method=add_method,
+                add_name=add_name,
+                method_val=method_val,
+                name_val=name_val,
+            )
+            changes.append(
+                f"line {h_open_i + 1}: added routing headers to inline headers={{...}}"
+            )
+
+        # Pass 2: TODO above hand-rolled calls we could not fix mechanically.
+        out: list[str] = []
+        for i, raw_line in enumerate(lines):
+            if i in fixed_call_lines:
+                out.append(raw_line)
+                continue
+            if not HAND_ROLLED_CALL.search(raw_line):
+                out.append(raw_line)
+                continue
+            stripped = raw_line.lstrip(" \t")
+            if stripped.startswith("#"):
+                out.append(raw_line)
+                continue
+            if raw_line.rstrip("\n").rstrip().endswith(":"):
+                out.append(raw_line)
+                continue
+
+            indent = raw_line[: len(raw_line) - len(stripped)]
+            newline = "\n" if raw_line.endswith("\n") else ""
+            if not (out and out[-1].strip(" \t\n") == TODO):
+                out.append(f"{indent}{TODO}{newline}")
+                changes.append(f"line {i + 1}: added TODO for missing routing headers")
+            out.append(raw_line)
+
+        new_text = "".join(out)
+        if not changes:
+            return self.unchanged(source)
+        return self.result(new_text, changes)

--- a/src/mcp_migrate/rules/r003_routing_headers.py
+++ b/src/mcp_migrate/rules/r003_routing_headers.py
@@ -113,6 +113,23 @@ class MissingRoutingHeaders(Rule):
         if not imported_libs & set(HTTP_LIBS):
             return []
 
+        # Which files set these headers *in code*. `search_wire` skips
+        # comments but keeps ordinary string literals, which is exactly the
+        # distinction needed here: `headers={"Mcp-Method": ...}` is a string
+        # literal and must count, while a comment merely naming the header
+        # must not. `search_code` is the wrong tool -- it skips string
+        # literals, so it would never see a real header either.
+        #
+        # A raw `"Mcp-Method" in f.text` was the bug: R003's own fixer writes
+        # a TODO that names the header, so `fix --write` silenced the rule
+        # without setting anything, and `check` then reported "Grade A.
+        # Nothing to fix." on a file still missing the header entirely.
+        #
+        # Hoisted out of the per-file loop for the same reason `_check_ts`
+        # hoists its own scan -- see #67 and tests/test_scan_complexity.py.
+        sets_method = {f.path for f, _, _ in project.search_wire(r"Mcp-Method")}
+        sets_name = {f.path for f, _, _ in project.search_wire(r"Mcp-Name")}
+
         out: list[Finding] = []
         for f in project.files:
             if not any(lib in f.text for lib in HTTP_LIBS):
@@ -131,7 +148,7 @@ class MissingRoutingHeaders(Rule):
                 continue
             # Scoped to *this* file, not the whole project -- a header set
             # in some unrelated module doesn't mean this call site sends it.
-            missing_method = "Mcp-Method" not in f.text
+            missing_method = f.path not in sets_method
             # Mcp-Name is only required when the file is plausibly sending
             # one of the three methods that carry a name to route on. A
             # file that only ever mentions e.g. tools/list has nothing
@@ -139,7 +156,7 @@ class MissingRoutingHeaders(Rule):
             # this is the R003 bug fix: Mcp-Name is not required on every
             # POST, only on tools/call / resources/read / prompts/get.
             requires_name = bool(NAME_REQUIRED_RX.search(f.text))
-            missing_name = requires_name and "Mcp-Name" not in f.text
+            missing_name = requires_name and f.path not in sets_name
             if not missing_method and not missing_name:
                 continue
             i, line = hand_rolled[0]

--- a/tests/test_fixers.py
+++ b/tests/test_fixers.py
@@ -1309,6 +1309,139 @@ def test_r016_idempotent():
 
 
 # ---------------------------------------------------------------------------
+
+R003_INLINE_HEADERS_BEFORE = (
+    'import httpx\n'
+    '\n'
+    '_client = httpx.Client()\n'
+    '\n'
+    '\n'
+    'def call_tool(tool_name: str, arguments: dict) -> None:\n'
+    '    _client.post(\n'
+    '        "https://relay.internal/mcp",\n'
+    '        headers={"Content-Type": "application/json"},\n'
+    '        json={"jsonrpc": "2.0", "method": "tools/call", "params": {"name": tool_name, "arguments": arguments}},\n'
+    '    )\n'
+)
+R003_INLINE_HEADERS_AFTER = (
+    'import httpx\n'
+    '\n'
+    '_client = httpx.Client()\n'
+    '\n'
+    '\n'
+    'def call_tool(tool_name: str, arguments: dict) -> None:\n'
+    '    _client.post(\n'
+    '        "https://relay.internal/mcp",\n'
+    '        headers={"Content-Type": "application/json", "Mcp-Method": "tools/call", "Mcp-Name": tool_name},\n'
+    '        json={"jsonrpc": "2.0", "method": "tools/call", "params": {"name": tool_name, "arguments": arguments}},\n'
+    '    )\n'
+)
+
+R003_TODO_BEFORE = (
+    'import httpx\n'
+    '\n'
+    '_client = httpx.Client()\n'
+    '\n'
+    '\n'
+    'def notify(method: str, event: dict) -> None:\n'
+    '    _client.post(\n'
+    '        "https://hooks.internal.example.com/mcp-events",\n'
+    '        json={"jsonrpc": "2.0", "method": method, "params": event},\n'
+    '    )\n'
+)
+
+
+def test_r003_adds_routing_headers_to_inline_headers_dict():
+    result = fix("RoutingHeadersFixer", R003_INLINE_HEADERS_BEFORE)
+    assert result.changed
+    assert result.text == R003_INLINE_HEADERS_AFTER
+    assert FIXERS["RoutingHeadersFixer"].confidence == "review"
+    ast.parse(result.text)
+
+
+def test_r003_leaves_plain_rest_client_alone():
+    before = (
+        'import httpx\n'
+        '\n'
+        'def fetch_issue(issue_id: str):\n'
+        '    return httpx.get(f"https://jira.example.com/rest/api/2/issue/{issue_id}")\n'
+    )
+    result = fix("RoutingHeadersFixer", before)
+    assert result.changed is False
+    assert result.text == before
+
+
+def test_r003_adds_routing_headers_to_multiline_headers_dict():
+    before = (
+        'import httpx\n'
+        '\n'
+        '_client = httpx.Client()\n'
+        '\n'
+        '\n'
+        'def call_tool(tool_name: str, arguments: dict) -> None:\n'
+        '    _client.post(\n'
+        '        "https://relay.internal/mcp",\n'
+        '        headers={\n'
+        '            "Content-Type": "application/json",\n'
+        '        },\n'
+        '        json={"jsonrpc": "2.0", "method": "tools/call", "params": {"name": tool_name, "arguments": arguments}},\n'
+        '    )\n'
+    )
+    after = (
+        'import httpx\n'
+        '\n'
+        '_client = httpx.Client()\n'
+        '\n'
+        '\n'
+        'def call_tool(tool_name: str, arguments: dict) -> None:\n'
+        '    _client.post(\n'
+        '        "https://relay.internal/mcp",\n'
+        '        headers={\n'
+        '            "Content-Type": "application/json",\n'
+        '            "Mcp-Method": "tools/call",\n'
+        '            "Mcp-Name": tool_name,\n'
+        '        },\n'
+        '        json={"jsonrpc": "2.0", "method": "tools/call", "params": {"name": tool_name, "arguments": arguments}},\n'
+        '    )\n'
+    )
+    result = fix("RoutingHeadersFixer", before)
+    assert result.changed
+    assert result.text == after
+    ast.parse(result.text)
+
+
+def test_r003_adds_todo_when_headers_dict_is_not_inline():
+    result = fix("RoutingHeadersFixer", R003_TODO_BEFORE)
+    assert result.changed
+    assert result.text.count("TODO(mcp-migrate): add Mcp-Method") == 1
+    assert result.text.index("TODO(mcp-migrate)") < result.text.index("_client.post(")
+    assert '"Mcp-Method":' not in result.text
+    ast.parse(result.text)
+
+
+def test_r003_refuses_to_guess_on_headers_variable():
+    before = (
+        'import httpx\n'
+        '\n'
+        'def relay(method: str, payload: dict, base_headers: dict) -> None:\n'
+        '    httpx.post("https://relay/mcp", headers=base_headers, json={"method": method, "jsonrpc": "2.0"})\n'
+    )
+    result = fix("RoutingHeadersFixer", before)
+    assert result.changed
+    assert "TODO(mcp-migrate)" in result.text
+    assert "headers=base_headers" in result.text
+    assert '"Mcp-Method":' not in result.text
+    ast.parse(result.text)
+
+
+def test_r003_idempotent():
+    once = fix("RoutingHeadersFixer", R003_INLINE_HEADERS_BEFORE)
+    twice = fix("RoutingHeadersFixer", once.text)
+    assert twice.changed is False
+    assert twice.text == once.text
+
+
+# ---------------------------------------------------------------------------
 # CLI: fix / fixers
 # ---------------------------------------------------------------------------
 
@@ -1571,3 +1704,44 @@ def test_typescript_fixes_stay_idempotent():
     twice = fixer.fix(once, Path("server.ts"))
 
     assert not twice.changed, "second run must be a no-op"
+
+
+def test_r003_never_writes_a_placeholder_value():
+    """The fixer used to fall back to `"Mcp-Method": "<set-mcp-method>"` when
+    it could not recover the method from the call site. That compiles, runs,
+    and sends a literal `Mcp-Method: <set-mcp-method>` header -- and because
+    the header name is now present, `check` reported "Grade A. Nothing to
+    fix." immediately afterwards. An actionable finding became a broken
+    header the tool then called clean."""
+    before = (
+        "import httpx\n"
+        "\n"
+        "def send(payload):\n"
+        "    # tools/call resources/read jsonrpc\n"
+        '    return httpx.post("https://x/mcp", headers={"Accept": "application/json"}, data=payload)\n'
+    )
+    result = fix("RoutingHeadersFixer", before)
+    assert "set-mcp-method" not in result.text
+    assert "set-mcp-name" not in result.text
+    # It still says something -- it just says it in a comment, and leaves
+    # the call site exactly as it found it.
+    assert "TODO(mcp-migrate)" in result.text
+    assert 'headers={"Accept": "application/json"}' in result.text
+
+
+def test_r003_still_writes_values_it_can_actually_recover():
+    """Refusing to guess must not cost the case the fixer exists for."""
+    before = (
+        "import httpx\n"
+        "\n"
+        "def call_tool(name, args):\n"
+        "    return httpx.post(\n"
+        '        "https://x/mcp",\n'
+        '        headers={"Content-Type": "application/json"},\n'
+        '        json={"method": "tools/call", "params": {"name": name}},\n'
+        "    )\n"
+    )
+    result = fix("RoutingHeadersFixer", before)
+    assert result.changed
+    assert '"Mcp-Method": "tools/call"' in result.text
+    assert '"Mcp-Name": name' in result.text

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -217,3 +217,40 @@ def test_issue_87_bounding_does_not_cost_the_real_sdk_names(rule_id, source, ext
     assert rule_id in {f.rule_id for f in findings}, (
         f"{rule_id} no longer catches {source!r} in a {ext} file -- bounding overshot"
     )
+
+
+def test_r003_is_not_silenced_by_a_comment_naming_the_header(tmp_path):
+    """R003 decided "is this header set?" with a raw substring test over the
+    whole file, comments included. Its own fixer writes a TODO that names
+    `Mcp-Method`, so running `fix --write` made the rule stop firing without
+    anything having been set -- `check` then reported the file clean while
+    the header was still missing. `search_wire` keeps string literals (where
+    a real header lives) and skips comments (where a TODO lives)."""
+    (tmp_path / "a.py").write_text(
+        "import httpx\n"
+        "\n"
+        "def send(payload):\n"
+        "    # tools/call resources/read jsonrpc\n"
+        "    # TODO(mcp-migrate): add Mcp-Method (and Mcp-Name ...)\n"
+        '    return httpx.post("https://x/mcp", headers={"Accept": "*/*"}, data=payload)\n'
+    )
+    _, _, findings, _, _ = run_check(tmp_path)
+    assert "R003" in {f.rule_id for f in findings}, (
+        "a comment naming Mcp-Method must not count as setting it"
+    )
+
+
+def test_r003_is_satisfied_by_a_real_header_in_a_string_literal(tmp_path):
+    """The other direction: the header only ever appears as a dict key, so
+    a code-only search would never see it and the rule would fire forever."""
+    (tmp_path / "a.py").write_text(
+        "import httpx\n"
+        "\n"
+        "def send(payload):\n"
+        '    return httpx.post("https://x/mcp",\n'
+        '        headers={"Mcp-Method": "tools/list"}, data=payload)\n'
+    )
+    _, _, findings, _, _ = run_check(tmp_path)
+    assert "R003" not in {f.rule_id for f in findings}, (
+        "a real header in a dict literal must count as setting it"
+    )


### PR DESCRIPTION
Rebuilds @syf2211's #106 onto current main. Their fixer and cookbook recipe verbatim, their six tests re-applied intact. Closes #16.

Full reasoning on #106. Two safety changes on top: the fixer no longer writes a `"<set-mcp-method>"` placeholder, and R003 no longer treats a comment naming the header as evidence the header is set.

519 tests pass.