### PR TITLE
Show suppression counts in the registry

### DIFF
--- a/registry/schema.yaml
+++ b/registry/schema.yaml
@@ -4,6 +4,7 @@ repo:          {required: true,  type: str,  desc: "owner/name on GitHub"}
 language:      {required: true,  type: str,  enum: [python, typescript, go, rust, java, csharp, ruby, other]}
 grade:         {required: true,  type: str,  enum: [A, B, C, D, F]}
 score:         {required: true,  type: int,  range: [0, 100]}
+suppressed:    {required: false, type: int,  desc: "non-negative count of findings suppressed when the grade was computed"}
 checked_with:  {required: true,  type: str,  desc: "mcp-migrate <version>"}
 spec:          {required: true,  type: str,  desc: "spec revision checked against"}
 status:        {required: true,  type: str,  enum: [ready, migrating, unmaintained]}

--- a/scripts/render_board.py
+++ b/scripts/render_board.py
@@ -28,8 +28,9 @@ def main() -> int:
     for e in entries:
         repo = e.get("repo", "")
         notes = str(e.get("notes", "")).strip().replace("|", "\\|")
+        suppression_note = f" ({e['suppressed']} suppressed)" if e.get("suppressed", 0) > 0 else ""
         rows.append(
-            f"| [{e.get('name')}](https://github.com/{repo}) | **{e.get('grade')}** "
+            f"| [{e.get('name')}](https://github.com/{repo}) | **{e.get('grade')}**{suppression_note} "
             f"| {EMOJI.get(e.get('status'), e.get('status'))} | {e.get('language')} | {notes} |"
         )
 

--- a/scripts/validate_registry.py
+++ b/scripts/validate_registry.py
@@ -122,6 +122,12 @@ def validate(path: Path) -> list[str]:
             errs.append(f"{path.name}: `{key}` must be one of {sorted(allowed)}, got {data[key]!r}")
     if "score" in data and not (isinstance(data["score"], int) and 0 <= data["score"] <= 100):
         errs.append(f"{path.name}: `score` must be an int 0-100")
+    if "suppressed" in data and not (
+        isinstance(data["suppressed"], int)
+        and not isinstance(data["suppressed"], bool)
+        and data["suppressed"] >= 0
+    ):
+        errs.append(f"{path.name}: `suppressed` must be a non-negative int")
     if "repo" in data and isinstance(data["repo"], str) and not REPO_RX.match(data["repo"]):
         errs.append(f"{path.name}: `repo` must look like owner/name")
     if "name" in data and data["name"] != path.stem:

--- a/src/mcp_migrate/cli.py
+++ b/src/mcp_migrate/cli.py
@@ -804,7 +804,8 @@ def cmd_entry(args) -> int:
         err.print(f"[bold red]No such path:[/bold red] {root}")
         return EXIT_UNSCANNABLE
 
-    project, _, findings, value, grade = run_check(root)
+    result = run_check_detailed(root)
+    project, value, grade = result.project, result.value, result.grade
     counts = survey(root)
 
     sdk_info = detect_sdk(root)
@@ -848,13 +849,16 @@ def cmd_entry(args) -> int:
 
     repo = args.repo or root.name
     slug = repo.split("/")[-1].lower().replace("_", "-")
+    suppressed_line = (
+        f"suppressed: {len(result.suppressed)}\n" if result.suppressed else ""
+    )
     body = f"""# registry/servers/{slug}.yaml
 name: {slug}
 repo: {repo}
 language: {language}
 grade: {grade}
 score: {value}
-checked_with: mcp-migrate {__version__}
+{suppressed_line}checked_with: mcp-migrate {__version__}
 spec: "{SPEC}"
 status: {"ready" if grade in "AB" else "migrating"}
 notes: >-

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -7,6 +7,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
+
 import render_board as rb
 import validate_registry as vr
 
@@ -68,6 +70,23 @@ def test_non_integer_score_is_an_error(tmp_path):
     path = _write(tmp_path, "acme-notes.yaml", content)
     errs = vr.validate(path)
     assert any("`score` must be an int 0-100" in e for e in errs)
+
+
+@pytest.mark.parametrize("suppressed", [0, 2])
+def test_non_negative_suppression_count_passes(tmp_path, suppressed):
+    content = VALID_ENTRY.replace(
+        "score: 97", f"score: 97\nsuppressed: {suppressed}"
+    )
+    path = _write(tmp_path, "acme-notes.yaml", content)
+    assert vr.validate(path) == []
+
+
+@pytest.mark.parametrize("value", ["-1", "1.5", '"2"', "true"])
+def test_invalid_suppression_count_is_an_error(tmp_path, value):
+    content = VALID_ENTRY.replace("score: 97", f"score: 97\nsuppressed: {value}")
+    path = _write(tmp_path, "acme-notes.yaml", content)
+    errs = vr.validate(path)
+    assert any("`suppressed` must be a non-negative int" in e for e in errs)
 
 
 def test_malformed_repo_string_is_an_error(tmp_path):
@@ -198,6 +217,29 @@ def test_render_board_sorts_by_grade_then_score(tmp_path, monkeypatch):
     assert rb.main() == 0
     text = readme.read_text()
     assert text.index("acme-notes") < text.index("low-grade")
+
+
+def test_render_board_marks_only_entries_with_suppressions(tmp_path, monkeypatch):
+    servers_dir = tmp_path / "servers"
+    servers_dir.mkdir()
+    (servers_dir / "acme-notes.yaml").write_text(
+        VALID_ENTRY.replace("score: 97", "score: 97\nsuppressed: 2")
+    )
+    (servers_dir / "plain.yaml").write_text(
+        VALID_ENTRY.replace("name: acme-notes", "name: plain")
+    )
+
+    readme = tmp_path / "README.md"
+    readme.write_text("<!-- BOARD:START -->\n<!-- BOARD:END -->\n")
+    monkeypatch.setattr(rb, "SERVERS", servers_dir)
+    monkeypatch.setattr(rb, "README", readme)
+
+    assert rb.main() == 0
+    text = readme.read_text()
+    acme_row = next(line for line in text.splitlines() if "acme-notes" in line)
+    plain_row = next(line for line in text.splitlines() if "plain" in line)
+    assert "**A** (2 suppressed)" in acme_row
+    assert "suppressed" not in plain_row
 
 
 def test_render_board_fails_cleanly_without_markers(tmp_path, monkeypatch):

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -135,6 +135,7 @@ def test_cli_entry_command_prints_registry_yaml(capsys):
     assert "name: notes-mcp" in out
     assert "repo: acme/notes-mcp" in out
     assert "grade: A" in out
+    assert "suppressed:" not in out
 
 
 def test_unbounded_suffix_bounded_pattern_issue_87(tmp_path):

--- a/tests/test_suppress.py
+++ b/tests/test_suppress.py
@@ -165,6 +165,19 @@ def test_the_suppression_count_is_printed_without_a_flag(tmp_path, capsys):
     assert "suppressed" in out
 
 
+def test_entry_carries_the_suppression_count(tmp_path, capsys):
+    body = "import httpx\n" + f"{PY_TRIGGER}  # mcp-migrate: ignore[R001] -- deliberate\n"
+
+    exit_code = main([
+        "entry", str(project(tmp_path, "server.py", body)),
+        "--repo", "acme/notes-mcp",
+    ])
+    out = capsys.readouterr().out
+
+    assert exit_code == 0
+    assert "suppressed: 1" in out
+
+
 def test_show_suppressions_lists_each_one_with_its_reason(tmp_path, capsys):
     body = "import httpx\n" + f"{PY_TRIGGER}  # mcp-migrate: ignore[R001] -- proxy shim\n"
     main(["check", str(project(tmp_path, "server.py", body)), "--show-suppressions"])


### PR DESCRIPTION
## Summary

- Add an optional `suppressed` count to generated registry entries when non-zero.
- Validate the field and show the count on the registry board.

## Tests

- `uv run pytest -q`
- `uv run python scripts/validate_registry.py --offline`

Closes #220