### PR TITLE
fix: consolidate grade→color map into shared constants

### DIFF
--- a/scripts/render_badges.py
+++ b/scripts/render_badges.py
@@ -28,22 +28,14 @@ from pathlib import Path
 import yaml
 
 ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT / "src"))
+
 SERVERS = ROOT / "registry" / "servers"
 OUT = ROOT / "docs" / "badge"
 
 LABEL = "MCP 2026-07-28"
 
-# Must agree with how the grades read elsewhere, or the badge undermines
-# the thing it is reporting: a C rendered in green teaches the reader that
-# the colour means nothing, and then the next badge is not trusted either.
-GRADE_COLOR = {
-    "A": "brightgreen",
-    "B": "brightgreen",
-    "C": "yellow",
-    "D": "red",
-    "F": "red",
-}
-UNKNOWN_COLOR = "lightgrey"
+from mcp_migrate.constants import GRADE_COLOR, UNKNOWN_COLOR  # noqa: E402,F401
 
 # A 404 renders as a broken image on a stranger's README. Anyone can point
 # an endpoint URL at us -- including at a repo we have never scanned -- so

--- a/src/mcp_migrate/constants.py
+++ b/src/mcp_migrate/constants.py
@@ -1,0 +1,20 @@
+"""Shared constants used across the CLI and the badge renderer.
+
+The grade→color map must agree everywhere it is used, or the badge
+undermines the thing it is reporting: a C rendered in green teaches the
+reader that the colour means nothing, and then the next badge is not
+trusted either.
+"""
+
+# Five-step traffic-light: each grade has a distinct color.
+# This is the canonical map; both cli.py (badge_url) and
+# scripts/render_badges.py import from here.
+GRADE_COLOR = {
+    "A": "brightgreen",
+    "B": "green",
+    "C": "yellow",
+    "D": "orange",
+    "F": "red",
+}
+
+UNKNOWN_COLOR = "lightgrey"

--- a/src/mcp_migrate/grade.py
+++ b/src/mcp_migrate/grade.py
@@ -1,6 +1,7 @@
 """Turn findings into a single letter you can put in a README badge."""
 from __future__ import annotations
 
+from .constants import GRADE_COLOR
 from .rules.base import Finding, Rule
 
 WEIGHT = {"breaking": 25, "deprecated": 8, "advisory": 3}
@@ -12,8 +13,6 @@ WEIGHT = {"breaking": 25, "deprecated": 8, "advisory": 3}
 # mcp-atlassian's R003 hit 19 times before it was tightened, for 475 raw
 # penalty points -- more than 4x over from one rule alone.
 RULE_CAP = {"breaking": 25, "deprecated": 12, "advisory": 6}
-
-BADGE_COLOR = {"A": "brightgreen", "B": "green", "C": "yellow", "D": "orange", "F": "red"}
 
 
 def score(findings: list[Finding], rules: dict[str, Rule]) -> int:
@@ -45,5 +44,5 @@ def letter(value: int) -> str:
 
 
 def badge_url(grade: str) -> str:
-    color = BADGE_COLOR.get(grade, "lightgrey")
+    color = GRADE_COLOR.get(grade, "lightgrey")
     return f"https://img.shields.io/badge/MCP%202026--07--28-{grade}-{color}"

--- a/tests/test_badges.py
+++ b/tests/test_badges.py
@@ -53,12 +53,14 @@ def test_every_grade_renders_a_valid_endpoint_document(grade):
 
 
 @pytest.mark.parametrize("grade,color", [
-    ("A", "brightgreen"), ("B", "brightgreen"),
-    ("C", "yellow"), ("D", "red"), ("F", "red"),
+    ("A", "brightgreen"), ("B", "green"),
+    ("C", "yellow"), ("D", "orange"), ("F", "red"),
 ])
 def test_colours_match_the_grades(grade, color):
     # A C rendered in green teaches the reader that the colour means
     # nothing, and then the next badge is not trusted either.
+    # All five grades must have distinct colours so each carries a
+    # specific, trustworthy signal.
     assert badge_for(entry(grade=grade))["color"] == color
 
 
@@ -99,7 +101,7 @@ def test_a_multi_server_repo_reports_its_worst_grade():
     group = [entry(name="a", grade="A"), entry(name="b", grade="D"), entry(name="c", grade="B")]
     doc = badge_for_repo(group)
     assert doc["message"] == "D", "a repo containing a D must not advertise an A"
-    assert doc["color"] == "red"
+    assert doc["color"] == "orange"
     assert "3 servers" in doc["label"]
 
 


### PR DESCRIPTION
## Summary

Both `grade.py` (`badge_url`) and `render_badges.py` (live board) defined their own `GRADE_COLOR` map independently, and they disagreed on B and D:

| Grade | `grade.py` | `render_badges.py` |
|-------|-------------|---------------------|
| B | green | brightgreen |
| D | orange | red |

A B-graded project was told to paste a 'green' badge while its entry on the live board showed 'brightgreen'. On the board A and B were indistinguishable (both brightgreen) and D and F were indistinguishable (both red), collapsing a 5-value signal into a 3-value one.

## Fix

Consolidate into a single canonical map in `src/mcp_migrate/constants.py` and import it from both `grade.py` and `render_badges.py`.  The five-step traffic-light is preserved: each grade keeps its own colour so the signal is maximally informative.

## Changes

- **`src/mcp_migrate/constants.py`**: new file with the canonical `GRADE_COLOR` and `UNKNOWN_COLOR` constants
- **`src/mcp_migrate/grade.py`**: import `GRADE_COLOR` from constants; remove local `BADGE_COLOR` definition
- **`scripts/render_badges.py`**: import `GRADE_COLOR` and `UNKNOWN_COLOR` from constants; add `sys.path` manipulation to locate `src`
- **`tests/test_badges.py`**: update test expectations to match the five-step colour scheme

Closes #224.