### PR TITLE
fix(cli): refuse a fix target path that does not exist

### DIFF
--- a/src/mcp_migrate/cli.py
+++ b/src/mcp_migrate/cli.py
@@ -862,6 +862,14 @@ def cmd_fix(args) -> int:
         return 2
 
     root = Path(args.path).resolve()
+
+    if not root.exists():
+        # rglob over a path that isn't there yields nothing, which would
+        # otherwise fall through to the "Nothing to fix" branch and exit 0,
+        # making a stale CI path look clean forever (#237).
+        console.print(f"[bold red]No such path:[/bold red] {root}")
+        return EXIT_UNSCANNABLE
+
     cfg = load_config(root)
     for warning in cfg.warnings:
         console.print(f"[yellow]config warning[/yellow]  {warning}")

--- a/tests/test_unscannable.py
+++ b/tests/test_unscannable.py
@@ -129,6 +129,17 @@ def test_check_refuses_a_path_that_does_not_exist(tmp_path, capsys):
     assert "Grade" not in out
 
 
+def test_fix_refuses_a_path_that_does_not_exist(tmp_path, capsys):
+    # Same failure mode as `check`: `fix` on a missing directory used to
+    # fall through to "Nothing to fix" and exit 0, so a stale path in a
+    # CI invocation reported success forever (#237).
+    exit_code = main(["fix", str(tmp_path / "no-such-dir")])
+    out = capsys.readouterr().out
+    assert exit_code == 2
+    assert "No such path" in out
+    assert "Nothing to fix" not in out
+
+
 def test_check_still_grades_a_real_python_project(python_tree, capsys):
     exit_code = main(["check", str(python_tree), "--json"])
     data = json.loads(capsys.readouterr().out)


### PR DESCRIPTION
Fixes #237

**Problem** — `mcp-migrate fix` on a typo'd or stale directory used to fall through to the "Nothing to fix." branch and exit **0**, so a CI invocation pointed at a path that was never created reported success forever.

**Root cause** — `cmd_check` and `cmd_entry` both guard with `if not root.exists(): return EXIT_UNSCANNABLE`, but `cmd_fix` (added later) never got the same guard. `rglob` over a missing directory yields nothing, so the empty result quietly looked clean.

**Fix** — mirror the existing guard in `cmd_fix`: resolve the path, print `No such path:` and exit 2 before any scan happens.

**Test** — `test_fix_refuses_a_path_that_does_not_exist` alongside the existing `check` regression in `tests/test_unscannable.py`. Full suite: 675 passed.