### PR TITLE
docs: add getting-started guide and full rule reference

### DIFF
--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -1,0 +1,175 @@
+# Getting Started
+
+`mcp-migrate` finds and fixes what the MCP 2026-07-28 spec revision breaks in
+your server. It is the only tool that edits your server's code for you: the
+official Python SDK ships no codemod for the protocol changes, and the
+TypeScript codemod only handles the v1→v2 package rename.
+
+## Install
+
+`mcp-migrate` is a Python CLI published on PyPI. The fastest way to run it
+without installing anything into your project is `uvx`:
+
+```bash
+uvx mcp-migrate --help
+```
+
+Alternatively, install it into your environment:
+
+```bash
+pip install mcp-migrate
+# or
+uv tool install mcp-migrate
+```
+
+## Check a server
+
+Point the tool at the root of your server project:
+
+```bash
+uvx mcp-migrate check .
+```
+
+The report lists every finding with its rule id, severity (`breaking`,
+`deprecated`, `advisory`), file, and line, then prints a letter grade and a
+score out of 100. A clean tree prints `Grade A` and a ready-to-paste badge.
+
+Useful report flags:
+
+- `--json` — machine-readable output with the full, uncapped finding list
+  (the terminal table caps each rule at 5 rows).
+- `--format sarif` — SARIF 2.1.0 for GitHub code scanning.
+- `--rule R001` — run only specific rules (repeatable). The grade is
+  suppressed when a subset of rules runs, because a partial grade is not a
+  grade.
+- `--severity breaking` — only change what is *displayed*; the grade and
+  exit code are still computed from every finding.
+- `--fail-on {breaking,deprecated,advisory,never}` — the minimum severity
+  that fails the run (default `breaking`).
+- `--include-tests` — scan tests, fixtures, and examples (skipped by
+  default: backward-compat tests are evidence of good testing, not of a
+  broken server).
+
+### Exit codes
+
+| code | meaning |
+| ---- | ------- |
+| `0`  | checked it, nothing `breaking` |
+| `1`  | checked it, found something `breaking` |
+| `2`  | **could not check it** — no readable source in a supported language |
+
+Exit `2` means "we did not read your code", not "your code is fine". An
+empty finding set is only meaningful when the tool actually scanned the tree.
+
+## Fix a server
+
+`fix` runs in **dry-run mode by default** — it prints the exact unified diff
+and writes nothing:
+
+```bash
+uvx mcp-migrate fix .            # preview only
+uvx mcp-migrate fix . --write    # apply the changes
+```
+
+Every change is tagged in the diff output:
+
+- **`safe`** — the transformation cannot change behavior. Apply with
+  confidence.
+- **`review`** — the fixer did the mechanical part it is sure of and left a
+  `# TODO(mcp-migrate): ...` where a human must finish the job.
+
+Other fix flags:
+
+- `--safe-only` — apply only `safe` fixers.
+- `--rule R006` — restrict to specific rules (repeatable, same as `check`).
+- `--include-tests` — also fix test/fixture paths.
+
+Fixers are deliberately conservative: when a fixer cannot be certain a
+transformation is correct, it leaves the source untouched rather than guess.
+A wrong fix that silently corrupts your server is worse than reporting the
+finding and doing nothing.
+
+## Configure it
+
+Everything that is a flag can live in config so a team and CI share it.
+Put it in `[tool.mcp-migrate]` in `pyproject.toml`:
+
+```toml
+[tool.mcp-migrate]
+skip = ["vendor/", "generated/"]
+include-tests = false
+
+[tool.mcp-migrate.rules]
+R008 = "off"                                          # no reason recorded
+R016 = "off -- ttl is enforced by the gateway in front of this"
+```
+
+No `pyproject.toml`? Use a standalone `.mcp-migrate.toml` at the project
+root instead (most TypeScript projects fall here).
+
+Rules:
+
+- **A flag beats config, config beats the built-in default.**
+- **A disabled rule never runs** — it costs nothing against the grade and
+  `check` reports how many rules config switched off in every run.
+- **Malformed config** (bad TOML, unknown rule id, invalid rule value) does
+  not fail the run — it falls back to defaults and reports what it could
+  not understand (`config_warnings` in `--json`).
+
+## Suppress a false positive
+
+When a finding is wrong, or the code is deliberate and not changing, silence
+that one line rather than the whole rule:
+
+```python
+mcp_session_id = req.headers["X-Sid"]  # mcp-migrate: ignore[R001] -- proxy shim, not MCP session state
+```
+
+The rule id is required and a reason after `--` is expected. Suppressed
+findings **don't count against the grade**. `--show-suppressions` lists every
+one; stale suppressions that matched nothing are reported as
+`unused_suppressions`, so they don't accumulate silently in CI.
+
+**Caveat:** `R005`, `R015`, and `R016` report at most one finding per file,
+so suppressing their line silences the rule for the whole file.
+
+## Integrate with CI and pre-commit
+
+Pre-commit hook (a `breaking` finding fails the hook):
+
+```yaml
+# .pre-commit-config.yaml
+repos:
+  - repo: https://github.com/dheerajjha/mcp-migrate
+    rev: v0.2.0
+    hooks:
+      - id: mcp-migrate
+```
+
+The hook maps exit `2` ("could not check it") to `0` so a repo the tool
+cannot read does not block every commit.
+
+GitHub code scanning via SARIF:
+
+```yaml
+- run: mcp-migrate check . --format sarif > mcp-migrate.sarif
+- uses: github/codeql-action/upload-sarif@v3
+  with:
+    sarif_file: mcp-migrate.sarif
+```
+
+Severities map to SARIF levels: `breaking` -> `error`, `deprecated` ->
+`warning`, `advisory` -> `note`.
+
+## Understand the language support
+
+- **Python is graded.** TypeScript is scanned — every rule reads TypeScript —
+  but a letter grade is withheld pending the decision tracked in
+  [dheerajjha/mcp-migrate#172](https://github.com/dheerajjha/mcp-migrate/issues/172).
+- The exit code works on TypeScript regardless: a `breaking` finding exits
+  `1` with or without a grade, so TypeScript CI gates work today.
+
+## Next steps
+
+- See the full rule reference in [RULES_REFERENCE.md](RULES_REFERENCE.md).
+- Add your server to the board with `mcp-migrate entry --repo owner/name`.

--- a/docs/RULES_REFERENCE.md
+++ b/docs/RULES_REFERENCE.md
@@ -1,0 +1,61 @@
+# Rule Reference
+
+Every rule shipped by `mcp-migrate`, with its severity, what the 2026-07-28
+spec change breaks, and whether a fixer exists. Run `mcp-migrate rules` for
+the exact list of your installed version and `mcp-migrate fixers` for the
+fixer confidence table.
+
+## The 21 rules
+
+| Rule | Severity | What breaks | Fixer |
+| ---- | -------- | ------------ | ----- |
+| [R001](https://github.com/dheerajjha/mcp-migrate/blob/main/src/mcp_migrate/rules/r001_session_id_removed.py) | breaking | `Mcp-Session-Id` is gone from the Streamable HTTP transport ([SEP-2567](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2567)). | yes (`review`) |
+| [R002](https://github.com/dheerajjha/mcp-migrate/blob/main/src/mcp_migrate/rules/r002_connection_state.py) | breaking | Servers are required to be stateless ([SEP-2567](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2567)); a module-level dict keyed by connection breaks behind a load balancer or a restart. | yes (`review`) |
+| [R003](https://github.com/dheerajjha/mcp-migrate/blob/main/src/mcp_migrate/rules/r003_routing_headers.py) | advisory | Hand-rolled HTTP clients that skip the new required `Mcp-Method`/`Mcp-Name` [routing headers](https://modelcontextprotocol.io/specification/2026-07-28/basic/transports/streamable-http) get rejected by anything enforcing the new transport. | yes (`review`) |
+| [R004](https://github.com/dheerajjha/mcp-migrate/blob/main/src/mcp_migrate/rules/r004_tool_ordering.py) | advisory | [`tools/list` order](https://modelcontextprotocol.io/specification/draft/changelog) is not guaranteed; non-deterministic ordering defeats caching. | yes (`safe`) |
+| [R005](https://github.com/dheerajjha/mcp-migrate/blob/main/src/mcp_migrate/rules/r005_extensions.py) | advisory | Optional capabilities negotiate through an [`extensions`](https://modelcontextprotocol.io/specification/draft/changelog) map that isn't declared. | yes (`safe`) |
+| [R006](https://github.com/dheerajjha/mcp-migrate/blob/main/src/mcp_migrate/rules/r006_sse_transport_deprecated.py) | deprecated | [HTTP+SSE](https://modelcontextprotocol.io/specification/draft/changelog) is deprecated in favor of Streamable HTTP; stays in the spec 12+ months, then leaves. | yes (`review`) |
+| [R007](https://github.com/dheerajjha/mcp-migrate/blob/main/src/mcp_migrate/rules/r007_deprecated_features.py) | deprecated | [Roots, Sampling and Logging](https://modelcontextprotocol.io/specification/draft/changelog) are deprecated as core capabilities. | yes (`review`) |
+| [R008](https://github.com/dheerajjha/mcp-migrate/blob/main/src/mcp_migrate/rules/r008_trace_context.py) | advisory | Trace context (`traceparent`, `tracestate`, `baggage`) now travels in `_meta` ([SEP-414](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/414)); OpenTelemetry breaks at your server if it's never read. | yes (`review`) |
+| [R009](https://github.com/dheerajjha/mcp-migrate/blob/main/src/mcp_migrate/rules/r009_initialize_handshake_removed.py) | breaking | The `initialize`/`notifications/initialized` handshake ([SEP-2575](https://modelcontextprotocol.io/specification/2026-07-28/changelog)) is gone; a server still implementing it never becomes usable to a 2026-07-28 client. | yes (`review`) |
+| [R010](https://github.com/dheerajjha/mcp-migrate/blob/main/src/mcp_migrate/rules/r010_server_discover_missing.py) | advisory | Servers must implement [`server/discover`](https://modelcontextprotocol.io/specification/2026-07-28/changelog) ([SEP-2575](https://modelcontextprotocol.io/specification/2026-07-28/changelog)); registering handlers without it leaves clients with no way to learn what you support. | no |
+| [R011](https://github.com/dheerajjha/mcp-migrate/blob/main/src/mcp_migrate/rules/r011_ping_removed.py) | breaking | `ping` ([SEP-2575](https://modelcontextprotocol.io/specification/2026-07-28/changelog)) is removed from the protocol; liveness rides on the transport now. | yes (`review`) |
+| [R012](https://github.com/dheerajjha/mcp-migrate/blob/main/src/mcp_migrate/rules/r012_logging_set_level_removed.py) | breaking | `logging/setLevel` ([SEP-2575](https://modelcontextprotocol.io/specification/2026-07-28/changelog)) is removed; log level is per-request via `_meta` now. | yes (`review`) |
+| [R013](https://github.com/dheerajjha/mcp-migrate/blob/main/src/mcp_migrate/rules/r013_subscriptions_replaced.py) | breaking | `resources/subscribe`/`resources/unsubscribe` ([SEP-2575](https://modelcontextprotocol.io/specification/2026-07-28/changelog)) are replaced by `subscriptions/listen`. | yes (`review`) |
+| [R014](https://github.com/dheerajjha/mcp-migrate/blob/main/src/mcp_migrate/rules/r014_sse_resumability_removed.py) | breaking | SSE resumability via `Last-Event-ID` ([SEP-2575](https://modelcontextprotocol.io/specification/2026-07-28/changelog)) is removed; a dropped connection is just dropped now. | yes (`review`) |
+| [R015](https://github.com/dheerajjha/mcp-migrate/blob/main/src/mcp_migrate/rules/r015_result_type_required.py) | advisory | Every result now requires `resultType` ([SEP-2322](https://modelcontextprotocol.io/specification/2026-07-28/changelog)). Fires only on servers that build their own JSON-RPC envelopes. | no |
+| [R016](https://github.com/dheerajjha/mcp-migrate/blob/main/src/mcp_migrate/rules/r016_cacheable_result_required.py) | advisory | List/read results require `ttlMs`/`cacheScope` ([SEP-2549](https://modelcontextprotocol.io/specification/2026-07-28/changelog)). Advisory: nothing has adopted the new API yet. | yes (`review`) |
+| [R017](https://github.com/dheerajjha/mcp-migrate/blob/main/src/mcp_migrate/rules/r017_resource_not_found_code_changed.py) | breaking | The resource-not-found [error code](https://modelcontextprotocol.io/specification/2026-07-28/changelog) changed from `-32002` to `-32602`. | yes (`safe`) |
+| [R018](https://github.com/dheerajjha/mcp-migrate/blob/main/src/mcp_migrate/rules/r018_multi_round_trip_replaces_server_initiated.py) | breaking | Server-initiated Roots/Sampling/Elicitation ([SEP-2322](https://modelcontextprotocol.io/specification/2026-07-28/changelog)) are replaced by Multi Round-Trip Requests (`InputRequiredResult` + `inputResponses`). | yes (`review`) |
+| [R019](https://github.com/dheerajjha/mcp-migrate/blob/main/src/mcp_migrate/rules/r019_tasks_polling_replaces_blocking_result.py) | breaking | `tasks/list` is removed and blocking `tasks/result` ([SEP-2663](https://modelcontextprotocol.io/specification/2026-07-28/changelog)) is replaced by polling; Tasks moves to an extension. | yes (`review`) |
+| [R020](https://github.com/dheerajjha/mcp-migrate/blob/main/src/mcp_migrate/rules/r020_dynamic_client_registration_deprecated.py) | deprecated | RFC 7591 [Dynamic Client Registration](https://modelcontextprotocol.io/specification/2026-07-28/changelog) is deprecated in favor of Client ID Metadata Documents. | yes (`review`) |
+| [R021](https://github.com/dheerajjha/mcp-migrate/blob/main/src/mcp_migrate/rules/r021_json_schema_2020_12_required.py) | advisory | Implementations must support at least [JSON Schema 2020-12](https://modelcontextprotocol.io/specification/2026-07-28/changelog) ([SEP-2106](https://modelcontextprotocol.io/specification/2026-07-28/changelog)) for `inputSchema`/`outputSchema`. | yes (`safe`) |
+
+Only 19 of the 21 rules ship a fixer (R010 and R015 do not).
+
+## The grade
+
+Every finding costs points, but no single rule can sink a grade by itself:
+each rule's contribution is capped no matter how many times it fires.
+
+| Severity     | Cost per finding | Cap per rule |
+| ------------ | ----------------- | ------------ |
+| `breaking`   | -25                | -25           |
+| `deprecated` | -8                 | -12           |
+| `advisory`   | -3                 | -6            |
+
+Score starts at 100 and floors at 0. The letter grade:
+
+| Score  | Grade |
+| ------ | ----- |
+| 95-100 | A     |
+| 80-94  | B     |
+| 60-79  | C     |
+| 40-59  | D     |
+| 0-39   | F     |
+
+**The letter counts kinds of problem, not amount of work.** Because every
+rule is capped, one `Mcp-Session-Id` read and fourteen of them across four
+files both score 75 and both grade C. The score moves when a *different*
+rule fires, not when the same one fires again. To size a migration, read
+`counts` and `findings` in `--json` — they carry every occurrence, uncapped.


### PR DESCRIPTION
The `docs/` directory currently only ships `badge/` and `banner.jpg`; everything is crammed into the README. These two pages move the reference material out so the README can stay a pitch and the docs can be linked, embedded, and translated.

**`docs/GETTING_STARTED.md`** — install via `uvx`, `check` and its report flags, exit codes, `fix` semantics (`safe` vs `review`, dry-run default), config precedence, suppressions and their three file-scoped rule caveats, pre-commit/CI/SARIF integration, and the Python/TypeScript grading situation.

**`docs/RULES_REFERENCE.md`** — the 21-rule table (severity, spec change, fixer confidence) plus the grading caps and score-to-letter mapping.

Content is drawn from the current README and `mcp-migrate rules` output; no behavior changes.