### PR TITLE
fix(cli): preserve language in fix summary

### DIFF
--- a/src/mcp_migrate/cli.py
+++ b/src/mcp_migrate/cli.py
@@ -943,10 +943,10 @@ def cmd_fix(args) -> int:
     for f in project.files:
         text = fixed_by_path.get(f.path, f.text)
         try:
-            tree = ast.parse(text, filename=str(f.path))
+            tree = ast.parse(text, filename=str(f.path)) if f.language == "python" else None
         except SyntaxError:
             tree = None
-        post_fix_files.append(SourceFile(path=f.path, text=text, tree=tree))
+        post_fix_files.append(SourceFile(path=f.path, text=text, tree=tree, language=f.language))
     remaining = _findings_for(root, post_fix_files, disabled=cfg.disabled_rules)
     if remaining:
         console.print(f"[yellow]{len(remaining)} finding(s) still need a human after this fix "

--- a/tests/test_typescript.py
+++ b/tests/test_typescript.py
@@ -1827,3 +1827,22 @@ export const STACK = "mcp";
 """
     project = load_project(_write(tmp_path, "server.ts", code)).for_language("typescript")
     assert PerConnectionState().check(project) == []
+
+def test_fix_preserves_typescript_language_for_remaining_findings(tmp_path, capsys):
+    path = _write(tmp_path, "transport.ts", LEGACY_TS)
+
+    fix_exit = main(["fix", str(tmp_path), "--write"])
+    fix_output = capsys.readouterr().out
+
+    check_exit = main(["check", str(tmp_path), "--json"])
+    check_data = json.loads(capsys.readouterr().out)
+
+    remaining_line = next(
+        line
+        for line in fix_output.splitlines()
+        if "finding(s) still need a human after this fix" in line
+    )
+    remaining = int(remaining_line.split()[0])
+
+    assert remaining == len(check_data["findings"])
+    assert fix_exit == 0


### PR DESCRIPTION
## Summary

Fixes #238.

- Preserve each source file's language when rebuilding files after `fix`.
- Only parse Python files with `ast.parse`.
- Add a regression test ensuring `fix` and `check` report the same remaining TypeScript findings.

## Tests

- `uv run pytest`
- 675 passed