### PR TITLE
fix(config): warn about unknown rule ids

### DIFF
--- a/src/mcp_migrate/cli.py
+++ b/src/mcp_migrate/cli.py
@@ -71,6 +71,23 @@ class CheckResult:
     disabled_rules: dict  # rule id -> reason, for rules a project config switched off
 
 
+def _validate_configured_rules(config: Config, known_rule_ids) -> dict[str, str]:
+    """Return configured rule disables that name a registered rule."""
+    known = sorted(known_rule_ids)
+    known_set = set(known)
+    for rule_id in sorted(set(config.disabled_rules) - known_set):
+        suggestion = difflib.get_close_matches(rule_id, known, n=1)
+        if suggestion:
+            guidance = f"did you mean {suggestion[0]}?"
+        else:
+            guidance = f"see `mcp-migrate rules` for the {len(known)} that exist"
+        source = config.source or "config"
+        warning = f"{source}: no rule {rule_id} -- {guidance}"
+        if warning not in config.warnings:
+            config.warnings.append(warning)
+    return {rid: reason for rid, reason in config.disabled_rules.items() if rid in known_set}
+
+
 def run_check_detailed(
     root: Path, *, include_tests: bool = False, rule_ids: frozenset[str] | None = None, config: Config | None = None,
 ) -> "CheckResult":
@@ -83,7 +100,7 @@ def run_check_detailed(
     effective_include_tests = include_tests or config.include_tests
     project = load_project(root, include_tests=effective_include_tests, extra_skip=config.skip)
     rules = {r.id: r for r in all_rules()}
-    disabled_rules = {rid: reason for rid, reason in config.disabled_rules.items() if rid in rules}
+    disabled_rules = _validate_configured_rules(config, rules)
     findings = []
     # One pass per (rule, language it declares), against a project view
     # filtered to that language. Views are cached because building one
@@ -863,12 +880,13 @@ def cmd_fix(args) -> int:
 
     root = Path(args.path).resolve()
     cfg = load_config(root)
+    disabled_rules = _validate_configured_rules(cfg, (rule.id for rule in all_rules()))
     for warning in cfg.warnings:
         console.print(f"[yellow]config warning[/yellow]  {warning}")
 
     rule_ids = frozenset(args.rule) if args.rule else None
-    fixers = _select_fixers(safe_only=args.safe_only, rule_ids=rule_ids, disabled=cfg.disabled_rules)
-    skipped = {fx.rule_id for fx in all_fixers()} & set(cfg.disabled_rules)
+    fixers = _select_fixers(safe_only=args.safe_only, rule_ids=rule_ids, disabled=disabled_rules)
+    skipped = {fx.rule_id for fx in all_fixers()} & set(disabled_rules)
     if skipped and not rule_ids:
         console.print(
             f"[dim]{len(skipped)} fixer(s) skipped, disabled by config ({cfg.source}): "

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -125,6 +125,36 @@ R001 = "off -- deliberate"
     assert result.disabled_rules == {"R001": "deliberate"}
 
 
+def test_unknown_rule_id_warns_and_is_not_disabled(tmp_path):
+    _write(tmp_path, "server.py", PY_TRIGGER)
+    _write(tmp_path, "pyproject.toml", """
+[tool.mcp-migrate.rules]
+R999 = "off -- typo"
+""")
+
+    result = run_check_detailed(tmp_path)
+
+    assert result.disabled_rules == {}
+    assert result.config.disabled_rules == {"R999": "typo"}
+    assert result.config.warnings == [
+        f"{tmp_path / 'pyproject.toml'}: no rule R999 -- "
+        "see `mcp-migrate rules` for the 21 that exist"
+    ]
+
+
+def test_registered_rule_id_does_not_warn(tmp_path):
+    _write(tmp_path, "server.py", PY_TRIGGER)
+    _write(tmp_path, "pyproject.toml", """
+[tool.mcp-migrate.rules]
+R001 = "off"
+""")
+
+    result = run_check_detailed(tmp_path)
+
+    assert result.disabled_rules == {"R001": ""}
+    assert result.config.warnings == []
+
+
 def test_a_disabled_rule_does_not_cost_the_grade(tmp_path):
     """The whole point: disabling a rule must not merely hide its findings
     from the report while still charging the score for them."""


### PR DESCRIPTION
Closes #239

## Summary

- validate configured rule IDs where the loaded config and live registry are both available
- preserve the config parser's independence from the rule registry
- surface a file-qualified warning with either a close-match suggestion or `mcp-migrate rules` guidance
- exclude unknown IDs from the effective disabled-rule map and apply the same validation to `fix`
- cover unknown and registered IDs with regression tests

## Validation

- `.venv/Scripts/python.exe -m pytest tests/test_config.py -q` — 21 passed
- `.venv/Scripts/python.exe -m pytest -q` — 676 passed
