### PR TITLE
fix(config): warn on unrecognised top-level keys instead of dropping them silently

### DIFF
--- a/src/mcp_migrate/cli.py
+++ b/src/mcp_migrate/cli.py
@@ -12,6 +12,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from rich.console import Console
+from rich.markup import escape
 from rich.table import Table
 
 from . import __version__
@@ -417,7 +418,7 @@ def _report_config(console, result: "CheckResult") -> None:
     makes for inline `ignore` comments applies here, one config-load earlier.
     """
     for warning in result.config.warnings:
-        console.print(f"[yellow]config warning[/yellow]  {warning}")
+        console.print(f"[yellow]config warning[/yellow]  {escape(warning)}")
 
     if not result.disabled_rules:
         return
@@ -930,7 +931,7 @@ def cmd_fix(args) -> int:
     cfg = load_config(root)
     disabled_rules = _validate_configured_rules(cfg, (rule.id for rule in all_rules()))
     for warning in cfg.warnings:
-        console.print(f"[yellow]config warning[/yellow]  {warning}")
+        console.print(f"[yellow]config warning[/yellow]  {escape(warning)}")
 
     rule_ids = frozenset(args.rule) if args.rule else None
     fixers = _select_fixers(safe_only=args.safe_only, rule_ids=rule_ids, disabled=disabled_rules)

--- a/src/mcp_migrate/config.py
+++ b/src/mcp_migrate/config.py
@@ -27,6 +27,7 @@ and is never mistaken for a pass, because it never produces one.
 """
 from __future__ import annotations
 
+import difflib
 import re
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -49,6 +50,13 @@ STANDALONE_FILENAME = ".mcp-migrate.toml"
 # one learns both.
 _OFF_RX = re.compile(r"^(?:off|disabled|false)\s*(?:(?:--|:)\s*(?P<reason>.+))?$", re.IGNORECASE)
 _ON_RX = re.compile(r"^(?:on|enabled|true)$", re.IGNORECASE)
+
+# Every key `_parse_table` actually consumes. Both spellings of the tests
+# toggle are accepted (the reader takes either); the dash form is the one
+# the docstring and README use, so it is the only one a "did you mean"
+# hint ever suggests back.
+_KNOWN_KEYS = frozenset({"skip", "include-tests", "include_tests", "rules"})
+_HINT_KEYS = ("skip", "include-tests", "rules")
 
 
 @dataclass
@@ -108,6 +116,37 @@ def _parse_table(table: dict, *, source: Path) -> Config:
                 )
     elif rules_table:
         warnings.append(f"{source}: `[rules]` must be a table, ignoring")
+
+    # A key this parser doesn't consume used to fall off the end in silence
+    # -- the one misconfiguration the module let pass without the scrutiny it
+    # already applies one level down in `[rules]`. That silence is worse here
+    # than for an ordinary typo'd setting: a `skip` that never took effect or
+    # a rule toggle that never applied leaves the published grade different
+    # from the configured one, with no output that differs to reveal it, in a
+    # tool whose entire proposition is that the grade is trustworthy. So warn
+    # for every unrecognised key, and where the key is a recognisable mistake
+    # rather than noise, say what the right shape is.
+    is_standalone = source.name == STANDALONE_FILENAME
+    rules_label = "[rules]" if is_standalone else "[tool.mcp-migrate.rules]"
+    for key in table:
+        if key in _KNOWN_KEYS:
+            continue
+        if RULE_ID_RX.match(key):
+            warnings.append(
+                f"{source}: {key!r} is a rule id at the top level, ignoring "
+                f"-- rule toggles go in the {rules_label} table"
+            )
+        elif key == "tool" and is_standalone:
+            warnings.append(
+                f"{source}: unknown setting 'tool', ignoring -- "
+                f"`[tool.mcp-migrate]` is the pyproject.toml spelling; in "
+                f"{STANDALONE_FILENAME} the settings are top level "
+                f"(`skip`, `include-tests`, and a `[rules]` table)"
+            )
+        else:
+            near = difflib.get_close_matches(key, _HINT_KEYS, n=1)
+            hint = f" -- did you mean {near[0]!r}?" if near else ""
+            warnings.append(f"{source}: unknown setting {key!r}, ignoring{hint}")
 
     return Config(
         skip=frozenset(skip), include_tests=include_tests,

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -109,6 +109,75 @@ def test_non_rule_id_key_in_rules_table_is_reported(tmp_path):
     assert any("not-a-rule" in w for w in cfg.warnings)
 
 
+# --- unknown top-level keys ------------------------------------------------
+# The mirror of the [rules] checks above, one level up: a setting the parser
+# doesn't consume must be *visible*, not silently dropped, for the same
+# reason -- a grade you can't tell was misconfigured is not a grade.
+
+def test_unknown_top_level_key_is_reported_not_silently_dropped(tmp_path):
+    _write(tmp_path, "pyproject.toml", '[tool.mcp-migrate]\nfrobnicate = true\n')
+    cfg = load_config(tmp_path)
+    assert cfg.skip == frozenset()
+    assert cfg.disabled_rules == {}
+    assert any("frobnicate" in w for w in cfg.warnings)
+
+
+def test_a_fully_valid_config_produces_no_warnings(tmp_path):
+    """The regression that actually bites: a warning that fires on a correct
+    config is worse than no warning at all."""
+    _write(tmp_path, "pyproject.toml", """
+[tool.mcp-migrate]
+skip = ["vendor/"]
+include-tests = true
+
+[tool.mcp-migrate.rules]
+R001 = "off -- deliberate"
+""")
+    cfg = load_config(tmp_path)
+    assert cfg.warnings == []
+    assert cfg.skip == frozenset({"vendor"})
+    assert cfg.include_tests is True
+    assert cfg.disabled_rules == {"R001": "deliberate"}
+
+
+def test_underscore_spelling_of_include_tests_is_accepted_silently(tmp_path):
+    _write(tmp_path, "pyproject.toml", "[tool.mcp-migrate]\ninclude_tests = true\n")
+    cfg = load_config(tmp_path)
+    assert cfg.include_tests is True
+    assert cfg.warnings == []
+
+
+def test_rule_id_at_top_level_points_at_the_rules_table(tmp_path):
+    _write(tmp_path, "pyproject.toml", '[tool.mcp-migrate]\nR010 = "off -- gateway"\n')
+    cfg = load_config(tmp_path)
+    assert cfg.disabled_rules == {}  # it did not take effect
+    assert any("R010" in w and "[tool.mcp-migrate.rules]" in w for w in cfg.warnings)
+
+
+def test_rule_id_at_top_level_in_standalone_names_the_bare_rules_table(tmp_path):
+    _write(tmp_path, ".mcp-migrate.toml", 'R010 = "off"\n')
+    cfg = load_config(tmp_path)
+    assert cfg.disabled_rules == {}
+    assert any(
+        "R010" in w and "[rules]" in w and "[tool.mcp-migrate.rules]" not in w
+        for w in cfg.warnings
+    )
+
+
+def test_pyproject_shaped_rules_table_in_standalone_names_the_spelling(tmp_path):
+    _write(tmp_path, ".mcp-migrate.toml", '[tool.mcp-migrate.rules]\nR010 = "off"\n')
+    cfg = load_config(tmp_path)
+    assert cfg.disabled_rules == {}  # the toggle silently did nothing before
+    assert any("pyproject.toml spelling" in w for w in cfg.warnings)
+
+
+def test_near_miss_on_a_real_key_suggests_it(tmp_path):
+    _write(tmp_path, "pyproject.toml", '[tool.mcp-migrate]\nskips = ["vendor"]\n')
+    cfg = load_config(tmp_path)
+    assert cfg.skip == frozenset()  # 'skips' did nothing
+    assert any("did you mean 'skip'" in w for w in cfg.warnings)
+
+
 # --- check integration -------------------------------------------------
 
 def test_a_disabled_rule_produces_no_finding_and_is_reported(tmp_path):
@@ -237,6 +306,18 @@ def test_check_json_surfaces_a_config_warning(tmp_path, capsys):
     out = json.loads(capsys.readouterr().out)
     assert len(out["config_warnings"]) == 1
     assert "R001" in out["config_warnings"][0]
+
+
+def test_config_warning_renders_toml_table_names_literally(tmp_path, capsys):
+    """A warning that names a TOML table must print the table, not let Rich
+    markup swallow the [brackets] into nothing -- the warning is only useful
+    if the reader can see the table it's being pointed at."""
+    _write(tmp_path, "server.py", "x = 1\n")
+    _write(tmp_path, "pyproject.toml", '[tool.mcp-migrate]\nR010 = "off"\n')
+    rc = main(["check", str(tmp_path)])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "[tool.mcp-migrate.rules]" in out
 
 
 def test_fix_skips_a_rule_disabled_by_config(tmp_path, capsys):


### PR DESCRIPTION
Fixes #235.

## What was wrong

`_parse_table` read exactly three keys (`skip`, `include-tests`/`include_tests`, `rules`) and let every other top-level key fall off the end in silence, even though the same function already warns about an unrecognised key one level down inside `[rules]`. As the issue lays out, that silence is worse here than for an ordinary typo, because a `skip` that never took effect or a rule toggle that never applied leaves the published grade different from the configured one, with no output that differs to reveal it, in a tool whose whole proposition is that the grade is trustworthy.

## The fix

One added block in `_parse_table`: collect the keys actually consumed and warn (never fail) for the rest, with a targeted hint for each of the three mistakes that actually happen:

1. **A rule id at the top level** (`R010 = "off"`) points at the rules table, spelled for the file it is in (`[tool.mcp-migrate.rules]` in `pyproject.toml`, bare `[rules]` in the standalone file).
2. **`tool` in a standalone `.mcp-migrate.toml`** (the case @dheerajjha added in the thread, copying the `pyproject.toml` shape into the standalone file) names both shapes so the reader knows which one belongs where.
3. **A near miss on a real key** (`skips`, `include-test`) gets a `difflib` "did you mean" suggestion.

## One related fix

The warning text names TOML tables like `[rules]`, and the two `console.print` sites were rendering warnings through Rich markup, which silently swallowed those brackets into empty backticks. That is a pre-existing bug (the existing `` `[rules]` must be a table `` warning shows it) that the new messages would otherwise inherit, so the warning text is now escaped at both sites. The stored strings and `--json` output are untouched.

## Evidence (running the thing)

```
# 1. rule id at the top level (pyproject.toml)
config warning  pyproject.toml: 'R010' is a rule id at the top level, ignoring -- rule toggles go in the [tool.mcp-migrate.rules] table

# 2. pyproject-shaped table in .mcp-migrate.toml
config warning  .mcp-migrate.toml: unknown setting 'tool', ignoring -- `[tool.mcp-migrate]` is the pyproject.toml spelling; in .mcp-migrate.toml the settings are top level (`skip`, `include-tests`, and a `[rules]` table)

# 3. near miss on a real key
config warning  pyproject.toml: unknown setting 'skips', ignoring -- did you mean 'skip'?

# regression: a fully valid config prints no config warning at all
1 rule(s) disabled by config (pyproject.toml): R001
```

## Tests

8 added in `tests/test_config.py`, one per case above plus the two regression guards the issue calls out specifically: a fully valid config emits **no** warnings, and the underscore alias `include_tests` stays accepted silently. Also one CLI test asserting a table name survives to rendered output (guards the escape fix). Full suite green:

```
698 passed
```

Warn, never fail, matching the existing `warnings` shape. Happy to adjust any of the hint wording.
