### PR TITLE
fix(config): walk up from the scan root to find project config

### DIFF
--- a/src/mcp_migrate/cli.py
+++ b/src/mcp_migrate/cli.py
@@ -419,6 +419,9 @@ def _report_config(console, result: "CheckResult") -> None:
     for warning in result.config.warnings:
         console.print(f"[yellow]config warning[/yellow]  {warning}")
 
+    if result.config.source is not None:
+        console.print(f"[dim]config: {result.config.source}[/dim]")
+
     if not result.disabled_rules:
         return
 

--- a/src/mcp_migrate/config.py
+++ b/src/mcp_migrate/config.py
@@ -129,18 +129,20 @@ def _load_toml(path: Path) -> dict | None | list[str]:
         return [f"{path}: invalid TOML, ignoring config ({e})"]
 
 
-def load_config(root: Path) -> Config:
-    """Load project config, or an empty one carrying only its warnings.
+def _load_config_at(level: Path) -> Config | None:
+    """Load config from one directory, or None if nothing there decides.
 
-    `pyproject.toml` wins if it exists at all, whether or not it actually
-    configures anything -- a project that has one and simply doesn't use
-    `[tool.mcp-migrate]` has given a complete answer ("nothing"), and going
-    on to also read a standalone file next to it would make the two files
-    silently fight over precedence. The standalone file is for projects
-    that have no `pyproject.toml` in the first place, which given what this
-    tool targets is most JavaScript and TypeScript ones.
+    `pyproject.toml` wins at a level if it exists at all, whether or not it
+    actually configures anything -- a project that has one and simply
+    doesn't use `[tool.mcp-migrate]` has given a complete answer
+    ("nothing") for that level, and going on to also read a standalone file
+    next to it would make the two files silently fight over precedence.
+    A section-less `pyproject.toml` returns None rather than an empty
+    config: in a monorepo the inner `pyproject.toml` is a packaging file
+    that says nothing about this tool, and treating its silence as an
+    answer would make `check src/` silently ignore the repo's real config.
     """
-    pyproject_path = root / "pyproject.toml"
+    pyproject_path = level / "pyproject.toml"
     if pyproject_path.is_file():
         data = _load_toml(pyproject_path)
         if isinstance(data, list):
@@ -151,9 +153,9 @@ def load_config(root: Path) -> Config:
             section = tool_table.get("mcp-migrate") or tool_table.get("mcp_migrate")
         if isinstance(section, dict):
             return _parse_table(section, source=pyproject_path)
-        return _empty()
+        return None
 
-    standalone_path = root / STANDALONE_FILENAME
+    standalone_path = level / STANDALONE_FILENAME
     if standalone_path.is_file():
         data = _load_toml(standalone_path)
         if isinstance(data, list):
@@ -162,4 +164,24 @@ def load_config(root: Path) -> Config:
             return _parse_table(data, source=standalone_path)
         return _empty()
 
-    return _empty()
+    return None
+
+
+def load_config(root: Path) -> Config:
+    """Load project config, or an empty one carrying only its warnings.
+
+    The config is searched for by walking up from `root`, so `check src/`
+    finds the repo's config at the repo root the way ruff, mypy, eslint, and
+    black all do. The walk stops at the first directory containing a `.git`
+    (the repo root), with the filesystem root as the backstop -- a stray
+    file in a parent directory outside the repo must never quietly change
+    someone's grade.
+    """
+    current = root.resolve()
+    while True:
+        found = _load_config_at(current)
+        if found is not None:
+            return found
+        if (current / ".git").exists() or current.parent == current:
+            return _empty()
+        current = current.parent

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -95,6 +95,75 @@ def test_malformed_toml_falls_back_to_defaults_with_a_warning(tmp_path):
     assert "invalid TOML" in cfg.warnings[0]
 
 
+# --- config discovery walks up from the scan root -------------------------
+
+def test_walks_up_to_repo_root_pyproject(tmp_path):
+    """`check src/` must find the repo's config at the repo root."""
+    _write(tmp_path, "pyproject.toml", """
+[tool.mcp-migrate.rules]
+R001 = "off"
+""")
+    cfg = load_config(tmp_path / "src")
+    assert cfg.disabled_rules == {"R001": ""}
+    assert cfg.source == tmp_path / "pyproject.toml"
+
+
+def test_walks_up_past_a_sectionless_inner_pyproject(tmp_path):
+    """A monorepo inner pyproject.toml that says nothing about this tool must
+    not stop the walk -- `check src/` still finds the repo root's config."""
+    _write(tmp_path, "pyproject.toml", """
+[tool.mcp-migrate.rules]
+R001 = "off"
+""")
+    _write(tmp_path / "src", "pyproject.toml", '[project]\nname = "inner-pkg"\n')
+    cfg = load_config(tmp_path / "src")
+    assert cfg.disabled_rules == {"R001": ""}
+    assert cfg.source == tmp_path / "pyproject.toml"
+
+
+def test_walks_up_to_standalone_file_in_parent(tmp_path):
+    _write(tmp_path, ".mcp-migrate.toml", 'skip = ["vendor"]\n')
+    cfg = load_config(tmp_path / "src")
+    assert cfg.skip == frozenset({"vendor"})
+    assert cfg.source == tmp_path / ".mcp-migrate.toml"
+
+
+def test_walk_stops_at_git_ceiling(tmp_path):
+    """A stray config above the repo root must never change the grade."""
+    _write(tmp_path, ".mcp-migrate.toml", 'skip = ["stray"]\n')
+    repo = tmp_path / "repo"
+    _write(repo, ".git", "")
+    cfg = load_config(repo / "src")
+    assert cfg.skip == frozenset()
+    assert cfg.source is None
+
+
+def test_walk_stops_at_filesystem_root_backstop(tmp_path):
+    """Even without a .git ceiling, the walk must terminate."""
+    _write(tmp_path, "pyproject.toml", '[tool.mcp-migrate]\nskip = ["top"]\n')
+    # No .git anywhere; walk from a deep dir up to the filesystem root and
+    # the config at tmp_path is between them, so it must still be found.
+    cfg = load_config(tmp_path / "a" / "b" / "c")
+    assert cfg.skip == frozenset({"top"})
+
+
+def test_check_text_reports_walked_up_config_source(tmp_path, capsys):
+    """The check output must say where the config came from when it was
+    found above the scan root, per the issue."""
+    _write(tmp_path, "pyproject.toml", """
+[tool.mcp-migrate.rules]
+R001 = "off"
+""")
+    _write(tmp_path / "src", "server.py", "x = 1\n")
+    rc = main(["check", str(tmp_path / "src")])
+    assert rc == 0
+    out = capsys.readouterr().out
+    # Rich wraps/truncates long paths across lines, so assert the line exists
+    # and that it names the walked-up config file rather than the exact path.
+    assert "config:" in out
+    assert "pyproject.toml" in out
+
+
 def test_unrecognised_rule_value_is_reported_not_silently_dropped(tmp_path):
     _write(tmp_path, ".mcp-migrate.toml", '[rules]\nR001 = "sometimes"\n')
     cfg = load_config(tmp_path)


### PR DESCRIPTION
## Summary

Fixes #236 — `mcp-migrate check src/` (or any subdirectory) now finds the repo's own config at the repo root instead of silently ignoring it.

## Changes

- `src/mcp_migrate/config.py`: `load_config` now walks up from the scan root looking for the first `pyproject.toml` containing `[tool.mcp-migrate]` or a standalone `.mcp-migrate.toml`. The walk stops at the first directory containing a `.git` (the repo root), with the filesystem root as a backstop, so a stray file in a parent directory outside the repo can never quietly change a grade.
  - Precedence is preserved per-directory: at each level a `pyproject.toml` that exists settles that level (the standalone file next to it is never read, so the two can't fight).
  - A section-less inner `pyproject.toml` (a monorepo packaging file that says nothing about this tool) no longer stops the walk — `check src/` still finds the repo root's real config.
- `src/mcp_migrate/cli.py`: the check output now always prints where the config came from (`config: <path>`), so a config found above the scan root is visible rather than action-at-a-distance.
- `tests/test_config.py`: six new tests covering walk-up to a root pyproject, walk-up past a section-less inner pyproject, walk-up to a parent standalone file, the `.git` ceiling, the filesystem-root backstop, and the printed config source.

## Validation

- Full suite: 696 passed (was 690 + 6 new)
- `ruff check` on changed files: no new violations (2 pre-existing in `tests/test_config.py` untouched code, 1 pre-existing in `config.py`)
