### PR TITLE
fix: strip import members instead of commenting them out (#245)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,17 @@ All notable changes to this project are documented here.
   This is a backstop, not a cure -- the individual fixers still make the bad
   edit, and that is tracked separately.
 
+- **Comment-out fixers no longer comment out import members.**
+  ([#245](https://github.com/dheerajjha/mcp-migrate/issues/245))
+
+  R009, R011, R012, R013 and R019 flag SDK type names that arrive in
+  parenthesised `from x import (A, B)` lists. Commenting each flagged member
+  line out left `from x import ( )`, which does not parse -- so the #244
+  guard refused the whole file and nothing got fixed. These fixers now
+  remove the flagged name from the list (a shared `strip_import_members`
+  helper), dropping the whole statement with its TODO when the list
+  empties, so the file stays parseable at every intermediate state.
+
 ### Changed
 
 - **`fix` can now exit `1`.** It previously only ever exited `0` (or `2` for

--- a/src/mcp_migrate/fixers/_textedit.py
+++ b/src/mcp_migrate/fixers/_textedit.py
@@ -9,10 +9,16 @@ splice, never an `ast.unparse` round-trip.
 """
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 OPEN = "([{"
 CLOSE = ")]}"
+
+# A parenthesised `from x import (` opener: the only import shape where a
+# fixer commenting out a member line leaves `from x import ( )`, which does
+# not parse (see `strip_parenthesised_import_members`).
+_FROM_IMPORT_PAREN_RX = re.compile(r"^\s*from\s+\S+\s+import\s*\(")
 
 
 def find_matching_close(lines: list[str], open_idx: int, open_col: int) -> tuple[int, int] | None:
@@ -52,6 +58,136 @@ def find_matching_close(lines: list[str], open_idx: int, open_col: int) -> tuple
 
 def leading_ws(line: str) -> str:
     return line[: len(line) - len(line.lstrip(" \t"))]
+
+
+def strip_import_members(lines, hit_fn, todo, label):
+    """Remove members of parenthesised `from x import (...)` statements whose
+    names ``hit_fn`` flags, instead of commenting the member lines out.
+
+    Commenting every member leaves ``from mcp.types import ( )``, which does
+    not parse, so the fix guard would refuse the whole file and nothing would
+    be fixed (#245). Removing the name keeps the import valid at every
+    intermediate state; if the list empties, the statement is removed
+    entirely. The TODO is placed above the ``from`` statement once.
+
+    ``hit_fn`` receives a single member name and returns a truthy description
+    when the fixer should drop it. Returns ``(new_lines, changes)`` where
+    ``changes`` describes each edited statement.
+    """
+    new_lines = list(lines)
+    changes: list[str] = []
+    i = 0
+    while i < len(new_lines):
+        if not _FROM_IMPORT_PAREN_RX.match(new_lines[i]):
+            i += 1
+            continue
+        open_idx = i
+        open_col = new_lines[i].index("(")
+        close = find_matching_close(new_lines, open_idx, open_col)
+        if close is None:
+            i += 1
+            continue
+        close_idx, close_col = close
+
+        edited_any = False
+        remaining_any = False
+
+        if close_idx == open_idx:
+            # Single-line import: edit the member text between the parens once.
+            head, tail = new_lines[open_idx][: open_col + 1], new_lines[open_idx][close_col:]
+            middle = new_lines[open_idx][open_col + 1 : close_col]
+            edited, remaining, changed = _strip_members_in_text(middle, hit_fn)
+            if changed:
+                new_lines[open_idx] = head + edited + tail
+                edited_any = True
+                remaining_any = remaining
+        else:
+            # Open line: member text after '(' (exclude the close paren).
+            head, tail = new_lines[open_idx][: open_col + 1], ""
+            middle = new_lines[open_idx][open_col + 1 :]
+            edited, remaining, changed = _strip_members_in_text(middle, hit_fn)
+            if changed:
+                new_lines[open_idx] = head + edited + tail
+                edited_any = True
+                remaining_any = remaining or remaining_any
+            elif middle.strip():
+                remaining_any = True  # untouched member text on the open line
+            # Middle member lines.
+            for j in range(open_idx + 1, close_idx):
+                line = new_lines[j]
+                stripped = line.strip()
+                if not stripped or stripped.startswith(("#", "//")):
+                    continue
+                edited, remaining, changed = _strip_members_in_text(line, hit_fn)
+                if not changed:
+                    remaining_any = True  # untouched member line: list non-empty
+                    continue
+                # A member-only line whose name was removed leaves just
+                # indentation -- blank it instead of leaving trailing
+                # whitespace (the import itself stays valid).
+                new_lines[j] = "" if not edited.strip(" \t\n") else edited
+                edited_any = True
+                remaining_any = remaining or remaining_any
+            # Close line: member text before ')'.
+            if new_lines[close_idx][:close_col].strip():
+                head, tail = "", new_lines[close_idx][close_col:]
+                middle = new_lines[close_idx][:close_col]
+                edited, remaining, changed = _strip_members_in_text(middle, hit_fn)
+                if changed:
+                    new_lines[close_idx] = head + edited + tail
+                    edited_any = True
+                    remaining_any = remaining or remaining_any
+                else:
+                    remaining_any = True  # untouched member text on the close line
+
+        if not edited_any:
+            i = close_idx + 1
+            continue
+        indent = leading_ws(new_lines[open_idx])
+        if remaining_any:
+            new_lines.insert(open_idx, f"{indent}{todo}\n")
+            changes.append(f"line {open_idx + 1}: removed {label} member(s) from the import")
+            i = close_idx + 2
+        else:
+            # The list emptied: drop the whole statement, keep the TODO.
+            new_lines[open_idx : close_idx + 1] = [f"{indent}{todo}\n"]
+            changes.append(f"line {open_idx + 1}: removed {label}; empty import dropped")
+            i = open_idx + 1
+    return new_lines, changes
+
+
+def _strip_members_in_text(text, hit_fn):
+    """Remove comma-separated members that ``hit_fn`` flags from ``text``.
+
+    Returns ``(new_text, remaining_any, changed)``. Leading indentation and a
+    trailing comment/newline are preserved; a line whose members are all
+    removed becomes indentation-only (the caller keeps or drops the line).
+    """
+    newline = "\n" if text.endswith("\n") else ""
+    body = text[: len(text) - len(newline)]
+    indent = leading_ws(body)
+    stripped = body.strip()
+    comment = ""
+    core = stripped
+    if "#" in core:
+        comment = core[core.index("#") :]
+        core = core[: core.index("#")]
+    trailing_comma = core.rstrip().endswith(",")
+    core = core.rstrip().rstrip(",").strip()
+    if not core:
+        return text, False, False
+    parts = [p.strip() for p in core.split(",") if p.strip()]
+    kept = [p for p in parts if not hit_fn(p)]
+    if len(kept) == len(parts):
+        return text, True, False
+    if not kept:
+        return indent + newline, False, True
+    joined = ", ".join(kept)
+    if trailing_comma:
+        joined += ","
+    if comment:
+        joined += "  " + comment
+    return indent + joined + newline, True, True
 
 
 def string_lines(source: str, path_or_lang: str | Path = "python") -> set[int]:

--- a/src/mcp_migrate/fixers/r009_initialize_handshake_removed.py
+++ b/src/mcp_migrate/fixers/r009_initialize_handshake_removed.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import re
 from pathlib import Path
 
+from ._textedit import strip_import_members
 from .base import Fixer, FixResult, comment_prefix, is_commented
 
 SPEC_URL = "https://modelcontextprotocol.io/specification/2026-07-28/changelog"
@@ -75,10 +76,11 @@ class InitializeHandshakeFixer(Fixer):
     def fix(self, source: str, path: Path) -> FixResult:
         lines = source.splitlines(keepends=True)
         out: list[str] = []
-        changes: list[str] = []
-
         prefix = comment_prefix(path)
         todo = f"{prefix}{TODO}"
+        # Remove import members from a parenthesised list rather than
+        # commenting them out, so `from x import ( )` is never produced (#245).
+        lines, changes = strip_import_members(lines, _handshake_hit, todo, "initialize handshake")
 
         for i, raw_line in enumerate(lines, start=1):
             stripped = raw_line.lstrip(" \t")

--- a/src/mcp_migrate/fixers/r011_ping_removed.py
+++ b/src/mcp_migrate/fixers/r011_ping_removed.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import re
 from pathlib import Path
 
+from ._textedit import strip_import_members
 from .base import Fixer, FixResult, comment_prefix, is_commented
 
 SPEC_URL = "https://modelcontextprotocol.io/specification/2026-07-28/changelog"
@@ -60,9 +61,12 @@ class PingRemovedFixer(Fixer):
     def fix(self, source: str, path: Path) -> FixResult:
         lines = source.splitlines(keepends=True)
         out: list[str] = []
-        changes: list[str] = []
         prefix = comment_prefix(path)
         todo = f"{prefix}{TODO_BODY}"
+        # An import member line must be removed from the list, never commented
+        # out: commenting every member leaves `from x import ( )` which does not
+        # parse, so the guard would refuse the whole file (#245).
+        lines, changes = strip_import_members(lines, _ping_hit, todo, "PingRequest/ping")
 
         for i, raw_line in enumerate(lines, start=1):
             stripped = raw_line.lstrip(" \t")

--- a/src/mcp_migrate/fixers/r012_logging_set_level_removed.py
+++ b/src/mcp_migrate/fixers/r012_logging_set_level_removed.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import re
 from pathlib import Path
 
+from ._textedit import strip_import_members
 from .base import Fixer, FixResult, comment_prefix, is_commented
 
 SPEC_URL = "https://modelcontextprotocol.io/specification/2026-07-28/changelog"
@@ -63,9 +64,11 @@ class LoggingSetLevelRemovedFixer(Fixer):
     def fix(self, source: str, path: Path) -> FixResult:
         lines = source.splitlines(keepends=True)
         out: list[str] = []
-        changes: list[str] = []
         prefix = comment_prefix(path)
         todo = f"{prefix}{TODO_BODY}"
+        # Remove import members from a parenthesised list rather than
+        # commenting them out, so `from x import ( )` is never produced (#245).
+        lines, changes = strip_import_members(lines, _set_level_hit, todo, "SetLevelRequest/logging/setLevel")
 
         for i, raw_line in enumerate(lines, start=1):
             stripped = raw_line.lstrip(" \t")

--- a/src/mcp_migrate/fixers/r013_subscriptions_replaced.py
+++ b/src/mcp_migrate/fixers/r013_subscriptions_replaced.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import re
 from pathlib import Path
 
+from ._textedit import strip_import_members
 from .base import Fixer, FixResult, comment_prefix, is_commented
 
 SPEC_URL = "https://modelcontextprotocol.io/specification/2026-07-28/changelog"
@@ -63,10 +64,11 @@ class SubscriptionsReplacedFixer(Fixer):
     def fix(self, source: str, path: Path) -> FixResult:
         lines = source.splitlines(keepends=True)
         out: list[str] = []
-        changes: list[str] = []
-
         prefix = comment_prefix(path)
         todo = f"{prefix}{TODO}"
+        # Remove import members from a parenthesised list rather than
+        # commenting them out, so `from x import ( )` is never produced (#245).
+        lines, changes = strip_import_members(lines, _subscribe_hit, todo, "Subscribe/UnsubscribeRequest")
 
         for i, raw_line in enumerate(lines, start=1):
             stripped = raw_line.lstrip(" \t")

--- a/src/mcp_migrate/fixers/r019_tasks_polling.py
+++ b/src/mcp_migrate/fixers/r019_tasks_polling.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 import re
 from pathlib import Path
 
-from ._textedit import string_lines
+from ._textedit import string_lines, strip_import_members
 from .base import Fixer, FixResult, comment_prefix, is_commented
 
 SPEC_URL = "https://modelcontextprotocol.io/specification/2026-07-28/changelog"
@@ -54,10 +54,11 @@ class TasksPollingFixer(Fixer):
     def fix(self, source: str, path: Path) -> FixResult:
         lines = source.splitlines(keepends=True)
         out: list[str] = []
-        changes: list[str] = []
-
         prefix = comment_prefix(path)
         todo = f"{prefix}{TODO}"
+        # Remove import members from a parenthesised list rather than
+        # commenting them out, so `from x import ( )` is never produced (#245).
+        lines, changes = strip_import_members(lines, _tasks_hit, todo, "tasks/list or tasks/result")
         # #105: a `#` inside a string literal opens no comment, so a TODO
         # written there silently edits the user's prose instead of
         # annotating their code.

--- a/tests/test_fixers.py
+++ b/tests/test_fixers.py
@@ -903,6 +903,79 @@ def test_r012_idempotent():
 
 
 # ---------------------------------------------------------------------------
+# #245 -- parenthesised import lists: strip members, never comment them out
+# ---------------------------------------------------------------------------
+# Commenting out every flagged member of `from mcp.types import (PingRequest)`
+# leaves `from mcp.types import ( )`, which does not parse -- so the fix guard
+# would refuse the whole file and nothing would be fixed. The comment-out
+# fixers must remove the flagged name from the list instead (dropping the
+# statement entirely if it empties), keeping the file parseable at every
+# intermediate state.
+
+# (fixer name, member the fixer flags, unrelated member kept on the list)
+IMPORT_STRIPPING_CASES = [
+    ("PingRemovedFixer", "PingRequest", "ListToolsRequest"),
+    ("LoggingSetLevelRemovedFixer", "SetLevelRequest", "ListToolsRequest"),
+    ("SubscriptionsReplacedFixer", "SubscribeRequest", "ListToolsRequest"),
+    ("InitializeHandshakeFixer", "InitializeRequest", "ListToolsRequest"),
+    ("TasksPollingFixer", "ListTasksRequest", "ListToolsRequest"),
+]
+
+
+@pytest.mark.parametrize("name,member,other", IMPORT_STRIPPING_CASES)
+def test_comment_out_fixer_strips_flagged_member_from_parenthesised_import(name, member, other):
+    before = f"from mcp.types import (\n    {member},\n    {other},\n)\n"
+    result = fix(name, before)
+    assert result.changed
+    assert f"    {other}," in result.text
+    assert member not in result.text
+    assert "TODO(mcp-migrate)" in result.text
+    ast.parse(result.text)  # the whole point of #245: stay parseable
+
+
+@pytest.mark.parametrize("name,member", [(n, m) for n, m, _ in IMPORT_STRIPPING_CASES])
+def test_comment_out_fixer_drops_import_when_list_empties(name, member):
+    before = f"from mcp.types import (\n    {member},\n)\n"
+    result = fix(name, before)
+    assert result.changed
+    assert "from mcp.types import" not in result.text
+    assert "TODO(mcp-migrate)" in result.text
+    ast.parse(result.text)
+
+
+@pytest.mark.parametrize("name,member,other", IMPORT_STRIPPING_CASES)
+def test_comment_out_fixer_import_strip_is_idempotent(name, member, other):
+    before = f"from mcp.types import (\n    {member},\n    {other},\n)\n"
+    once = fix(name, before)
+    twice = fix(name, once.text)
+    assert twice.changed is False
+    assert twice.text == once.text
+
+
+def test_r011_strips_member_from_single_line_parenthesised_import():
+    before = "from mcp.types import (PingRequest, ListToolsRequest)\n"
+    result = fix("PingRemovedFixer", before)
+    assert result.changed
+    assert "from mcp.types import (ListToolsRequest)" in result.text
+    assert "PingRequest" not in result.text
+    ast.parse(result.text)
+
+
+def test_r011_strips_member_when_comment_rides_on_the_import_line():
+    before = (
+        "from mcp.types import (\n"
+        "    PingRequest,  # legacy ping\n"
+        "    ListToolsRequest,\n"
+        ")\n"
+    )
+    result = fix("PingRemovedFixer", before)
+    assert result.changed
+    assert "PingRequest" not in result.text
+    assert "ListToolsRequest" in result.text
+    ast.parse(result.text)
+
+
+# ---------------------------------------------------------------------------
 # R017 -- resource-not-found error code
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Refs #245 (does not close it — the issue's own reproduction needs the sole-statement-body half too; see the maintainer comment below) — the comment-out fixers (R009, R011, R012, R013, R019) no longer
comment out members of a parenthesised `from x import (...)`. Commenting every
flagged member line left `from x import ( )`, which does not parse — so the
#244 parse guard refused the whole file and nothing got fixed.

## Changes

- `src/mcp_migrate/fixers/_textedit.py`: new shared `strip_import_members`
  helper. For a parenthesised `from x import (A, B, ...)` it removes the names
  a fixer flags instead of commenting the lines out (single-line, multi-line,
  and member-text-on-the-open/close-line shapes). The TODO is placed above the
  `from` statement once; if the list empties, the whole statement is dropped
  with the TODO, keeping the file parseable at every intermediate state.
- Wired into the five comment-out fixers whose hit regexes match SDK type
  names that can appear in import lists: `r009_initialize_handshake_removed.py`,
  `r011_ping_removed.py`, `r012_logging_set_level_removed.py`,
  `r013_subscriptions_replaced.py`, `r019_tasks_polling.py`.
  (R001 is untouched — its regex matches header access like
  `headers.get("Mcp-Session-Id")`, which can never be an import member.)
- `tests/test_fixers.py`: parametrized regression tests for all five fixers —
  member stripped (parseable), import dropped when it empties (parseable),
  idempotency — plus single-line and inline-comment shapes for R011.
- `CHANGELOG.md`: entry under Unreleased → Fixed.

## Validation

- Full suite: 707 passed (was 690; +17 new tests), 0 failed.
- The parseability guarantee is asserted directly in the tests via `ast.parse`
  on the fixer output — the exact failure mode #245 reported.

